### PR TITLE
Make StatsSummaryPanel scrollable

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -139,8 +139,10 @@ export default function Profile() {
                 </div>
 
                 <div className="space-y-6">
-                    <div className="sticky top-6">
-                        <StatsSummaryPanel />
+                    <div className="sticky top-6 h-[calc(100vh-10.5rem)] overflow-y-auto overscroll-y-auto custom-scrollbar">
+                        <div className="pb-6">
+                            <StatsSummaryPanel />
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
A simple addition to make the Stats Summary and Stats Comparison side panel self scrollable. 

### The Issue

If viewing either the Stats Summary or Stats Comparison,  you'd often have to scroll all the way to the end of the Profile page to scroll the final part of either summary into view. This can be an annoying user experience especially if you're making changes to your build and you want to see the passive skills in Stats Summary or the bottom part of the Stats Comparison (regen changes).

### The Change

Having to calculate the height like h-[calc(100vh-10.5rem)] is not ideal. However, due to the vertical spacing used within the profile, it is necessary to ensure there is enough space at the bottom of the stat panel. I also made sure there was enough room for the “Buy me a coffee” button so that it does not overlap with the end of the stat panel (see screenshots).

Lastly, I made sure to use the existing custom scrollbar CSS for consistency.

### Screenshots

#### Before:

You can see that the HRS panel is cut off and the buy me a coffee button is blokcing data. No way to scoll unless you go all the way to the bottom of the Profile page

<img width="1071" height="862" alt="before scroll fixx" src="https://github.com/user-attachments/assets/97ff84d9-a570-44d4-9247-fe980d828629" />


#### After

<img width="1246" height="933" alt="Monosnap ForgeMaster Helper 2026-02-17 17-38-19" src="https://github.com/user-attachments/assets/c211ef84-b924-4bc6-92e9-dafc622d25c1" />

#### Vid showing the scrolling
- Displays that you can freely scroll the stats panel 
- The displays that you can scroll the main profile page

https://github.com/user-attachments/assets/9956be95-dc48-4b32-9b0c-5a40ed34cde5



