### PR TITLE
Add Loadout Optimizer, lifesteal/sec, and character-stat source breakdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import MountCalculator from './pages/Calculators/MountCalculator';
 import SkillCalculator from './pages/Calculators/SkillCalculator';
 import TreeCalculator from './pages/Calculators/TreeCalculator';
 import WarPrizesCalculator from './pages/Calculators/WarPrizesCalculator';
+import LoadoutOptimizer from './pages/Calculators/LoadoutOptimizer';
 import Verify from './pages/Verify';
 import ForgeWiki from './pages/ForgeWiki';
 import SkinsPage from './pages/Skins';
@@ -83,6 +84,7 @@ function App() {
                                     <Route path="calculators/tree" element={<TreeCalculator />} />
                                     <Route path="calculators/substats" element={<SubstatsCalculator />} />
                                     <Route path="calculators/war-prizes" element={<WarPrizesCalculator />} />
+                                    <Route path="calculators/loadout" element={<LoadoutOptimizer />} />
                                     <Route path="solo-mission" element={<MissionSolo />} />
                                     <Route path="wiki/forge" element={<ForgeWiki />} />
                                     <Route path="wiki/base-drops" element={<BaseDrops />} />

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -133,6 +133,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                 { name: 'Mounts', path: '/calculators/mounts', icon: Star },
                 { name: 'War Prizes', path: '/calculators/war-prizes', icon: Trophy },
                 { name: 'Substats', path: '/calculators/substats', icon: Sliders },
+                { name: 'Loadout Optimizer', path: '/calculators/loadout', icon: Trophy },
             ]
         },
         {

--- a/src/components/Profile/LifestealBreakdownModal.tsx
+++ b/src/components/Profile/LifestealBreakdownModal.tsx
@@ -1,0 +1,227 @@
+import { memo, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '../UI/Button';
+import { X, Heart, Hash } from 'lucide-react';
+import { AggregatedStats } from '../../utils/statEngine';
+import { UserProfile } from '../../types/Profile';
+import { formatPercent } from '../../utils/statsCalculator';
+import { cn } from '../../lib/utils';
+
+import { formatNumber } from '../../utils/format';
+
+interface LifestealBreakdownModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    stats: AggregatedStats;
+    profile: UserProfile;
+    variant?: 'default' | 'original' | 'test';
+}
+
+// Internal component to handle content and memoization to prevent flickering
+const ModalContent = memo(({ stats, onClose, variant = 'default' }: Omit<LifestealBreakdownModalProps, 'isOpen'>) => {
+    const [showFullNumbers, setShowFullNumbers] = useState(false);
+    const [useRealTime, setUseRealTime] = useState(true);
+
+    // Local helper for compact formatting of large values
+    const formatVal = (val: number, decimals: number = 0) => {
+        if (showFullNumbers) return val.toLocaleString(undefined, { maximumFractionDigits: decimals });
+        return formatNumber(val);
+    };
+
+    // --- LIFESTEAL CALCULATIONS ---
+    const { sourceWeaponDps, lifeStealPct, rawLifesteal, blockChance, blockFactor, effectiveLifesteal } = useMemo(() => {
+        const weaponDps = useRealTime ? stats.realWeaponDps : stats.weaponDps;
+        const lsPct = stats.lifeSteal;
+        const raw = weaponDps * lsPct;
+        const bChance = Math.min(stats.blockChance || 0, 0.95);
+        const bFactor = 1 / (1 - bChance);
+        const effective = raw * bFactor;
+
+        return {
+            sourceWeaponDps: weaponDps,
+            lifeStealPct: lsPct,
+            rawLifesteal: raw,
+            blockChance: bChance,
+            blockFactor: bFactor,
+            effectiveLifesteal: effective
+        };
+    }, [stats, useRealTime]);
+
+    const hasLifesteal = lifeStealPct > 0;
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/85 backdrop-blur-[2px] p-2 md:p-4" onClick={onClose}>
+            <div className="bg-bg-primary w-full max-w-[calc(100vw-1rem)] md:max-w-3xl max-h-[95vh] rounded-2xl border border-border/60 shadow-2xl flex flex-col overflow-hidden animate-in zoom-in-95 fade-in duration-300" onClick={e => e.stopPropagation()}>
+                {/* Header */}
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between p-3 md:p-4 border-b border-border bg-bg-secondary/40 gap-4">
+                    <div className="flex items-center justify-between w-full sm:w-auto shrink min-w-0">
+                        <div className="flex items-center gap-2 md:gap-3 min-w-0">
+                            <Heart className="w-5 h-5 md:w-6 md:h-6 text-purple-400 shrink-0" />
+                            <div className="min-w-0">
+                                <h3 className="text-base md:text-xl font-bold text-white tracking-tight truncate">Lifesteal/sec Breakdown</h3>
+                                <p className="text-[8px] md:text-[10px] text-white/40 font-mono uppercase tracking-[0.1em] truncate">Math Analysis</p>
+                            </div>
+                        </div>
+
+                        {/* Mobile-only close to keep header balanced */}
+                        <button onClick={onClose} className="p-2 hover:bg-white/10 rounded-full transition-all text-white/60 hover:text-white sm:hidden shrink-0">
+                            <X className="w-5 h-5" />
+                        </button>
+                    </div>
+
+                    <div className="flex items-center gap-2 min-w-0 w-full sm:w-auto sm:justify-end overflow-x-auto no-scrollbar pb-1 sm:pb-0">
+                        <div className="flex items-center bg-bg-secondary rounded-lg p-1 border border-border/40 shrink-0">
+                            <button
+                                onClick={() => setUseRealTime(false)}
+                                className={cn(
+                                    "px-3 py-1.5 rounded-md text-[10px] font-bold uppercase transition-all shrink-0",
+                                    !useRealTime ? 'bg-purple-500 text-white shadow-lg' : 'text-white/40 hover:text-white/60'
+                                )}
+                            >
+                                <span>Theoretical</span>
+                            </button>
+                            <button
+                                onClick={() => setUseRealTime(true)}
+                                className={cn(
+                                    "px-3 py-1.5 rounded-md text-[10px] font-bold uppercase transition-all shrink-0",
+                                    useRealTime ? 'bg-purple-500 text-white shadow-lg' : 'text-white/40 hover:text-white/60'
+                                )}
+                            >
+                                <span>Real-Time</span>
+                            </button>
+                        </div>
+
+                        <div className="flex items-center gap-2 shrink-0 ml-auto sm:ml-0">
+                            <button
+                                onClick={() => setShowFullNumbers(!showFullNumbers)}
+                                className={cn(
+                                    "p-2 rounded-lg transition-all flex items-center gap-2",
+                                    showFullNumbers ? 'bg-purple-500/20 text-purple-400 ring-1 ring-purple-500/30' : 'hover:bg-white/5 text-white/40 hover:text-white/60'
+                                )}
+                                title={showFullNumbers ? "Switch to Compact Numbers" : "Show Full Numbers"}
+                            >
+                                <Hash className="w-4 h-4 md:w-5 md:h-5" />
+                                <span className={cn(showFullNumbers ? "inline" : "hidden lg:inline", "text-[10px] uppercase font-bold tracking-wider")}>
+                                    {showFullNumbers ? 'Full' : 'Compact'}
+                                </span>
+                            </button>
+                            <div className="w-px h-6 bg-border mx-1 hidden sm:block" />
+                            <button onClick={onClose} className="p-2 hover:bg-white/10 rounded-full transition-all text-white/60 hover:text-white hidden sm:block">
+                                <X className="w-5 h-5 md:w-6 md:h-6" />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Content */}
+                <div className="flex-1 overflow-y-auto p-4 md:p-8 space-y-8 md:space-y-10 custom-scrollbar bg-bg-primary font-sans">
+                    <section className="space-y-4 md:space-y-6">
+                        <div className="flex items-center gap-3 text-purple-400 font-bold uppercase text-[10px] md:text-[11px] tracking-[0.2em] border-b border-purple-500/20 pb-3 font-sans">
+                            <Heart className="w-4 h-4 md:w-5 md:h-5" />
+                            Lifesteal Scaling
+                        </div>
+
+                        {hasLifesteal ? (
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
+                                {/* Source Power */}
+                                <div className="bg-bg-input/40 rounded-2xl p-4 md:p-5 border border-white/5 space-y-3 min-w-0">
+                                    <div className="text-[10px] uppercase text-white/40 font-bold tracking-widest font-sans">Source Power</div>
+                                    <div className="flex justify-between items-baseline gap-2">
+                                        <span className="text-[11px] text-white/60">{useRealTime ? 'Real-Time' : 'Theoretical'} Weapon DPS</span>
+                                        <span className="text-base md:text-lg font-mono font-bold text-white break-all">{formatVal(sourceWeaponDps)}</span>
+                                    </div>
+                                    <div className="pt-3 border-t border-white/5 text-[9px] md:text-[10px] text-white/30 italic leading-relaxed">
+                                        Lifesteal applies to weapon hits only — skill damage does not lifesteal.
+                                    </div>
+                                </div>
+
+                                {/* LifeSteal % */}
+                                <div className="bg-bg-input/40 rounded-2xl p-4 md:p-5 border border-white/5 space-y-3 min-w-0">
+                                    <div className="text-[10px] uppercase text-white/40 font-bold tracking-widest font-sans">LifeSteal %</div>
+                                    <div className="flex justify-between items-baseline gap-2">
+                                        <span className="text-[11px] text-white/60">Chance / Ratio</span>
+                                        <span className="text-base md:text-lg font-mono font-bold text-purple-400 break-all">{formatPercent(lifeStealPct)}</span>
+                                    </div>
+                                </div>
+
+                                {/* Result */}
+                                <div className="bg-purple-500/10 rounded-2xl p-4 md:p-6 border border-purple-500/20 sm:col-span-2 group transition-all hover:bg-purple-500/[0.12]">
+                                    <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-3">
+                                        <div className="min-w-0 text-left">
+                                            <div className="text-[9px] md:text-[10px] uppercase text-purple-400 font-bold tracking-widest mb-1 font-sans">
+                                                Raw {useRealTime ? 'Real-Time' : 'Theoretical'} Lifesteal/sec
+                                            </div>
+                                            <div className="text-2xl sm:text-3xl md:text-4xl font-mono font-bold text-purple-400 drop-shadow-[0_0_15px_rgba(192,132,252,0.2)] break-all">
+                                                {formatVal(rawLifesteal)}
+                                            </div>
+                                        </div>
+                                        <div className="text-left md:text-right text-[10px] md:text-[11px] text-white/30 font-mono leading-relaxed max-w-sm flex flex-wrap md:flex-col gap-x-2">
+                                            <div className="text-purple-300/40 font-bold uppercase text-[8px] md:text-[9px] w-full mb-1">Calculation:</div>
+                                            <span className="whitespace-nowrap">WeaponDPS({formatVal(sourceWeaponDps)}) ×</span>
+                                            <span className="whitespace-nowrap">LifeSteal({formatPercent(lifeStealPct)})</span>
+                                        </div>
+                                    </div>
+
+                                    {blockChance > 0 && (
+                                        <div className="mt-4 pt-4 border-t border-purple-500/20 flex flex-col md:flex-row md:justify-between md:items-center gap-2">
+                                            <div className="text-[10px] md:text-[11px] text-white/40 font-mono">
+                                                Block Amplification: <span className="text-purple-300 font-bold">×{blockFactor.toFixed(2)}</span> ({formatPercent(blockChance)} block)
+                                            </div>
+                                            <div className="text-right">
+                                                <div className="text-[8px] md:text-[9px] uppercase text-white/40 font-bold tracking-wider font-sans">Effective Lifesteal/sec</div>
+                                                <div className="text-base md:text-lg font-mono font-bold text-purple-300">{formatVal(effectiveLifesteal)}</div>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="text-center py-10 bg-bg-input/20 rounded-2xl border border-dashed border-white/10 text-white/30 text-[11px] italic font-mono">
+                                No lifesteal on this build
+                            </div>
+                        )}
+                    </section>
+                </div>
+
+                {/* Footer */}
+                <div className="p-4 md:p-6 border-t border-border bg-bg-secondary flex flex-col md:flex-row gap-4 md:items-center font-mono">
+                    <div className="flex-1 flex flex-wrap items-center justify-between md:justify-start gap-x-4 gap-y-3 md:gap-8 min-w-0">
+                        <div className="flex flex-col min-w-0">
+                            <span className="text-[8px] md:text-[9px] uppercase text-purple-400 font-bold tracking-widest bg-purple-500/10 px-2 py-1 rounded-md mb-1 leading-none font-sans w-fit">
+                                Total {useRealTime ? 'Real-Time' : 'Theoretical'} Lifesteal/sec
+                            </span>
+                            <span className="text-xl sm:text-2xl md:text-3xl font-bold text-white drop-shadow-[0_0_15px_rgba(255,255,255,0.2)] leading-none mt-1 break-all">
+                                {formatVal(rawLifesteal)}
+                            </span>
+                        </div>
+                        {blockChance > 0 && (
+                            <div className="flex flex-col min-w-0">
+                                <span className="text-[8px] md:text-[9px] uppercase text-white/40 font-bold tracking-wider leading-none mb-1 font-sans">Effective (Block-Amplified)</span>
+                                <span className="text-sm md:text-xl font-bold text-purple-300 leading-none truncate">
+                                    {formatVal(effectiveLifesteal)}
+                                </span>
+                            </div>
+                        )}
+                    </div>
+                    <Button onClick={onClose} variant="primary" className="w-full md:w-auto px-8 py-2 md:py-3 text-sm md:text-base shadow-xl active:scale-95 transition-all shrink-0">Close</Button>
+                </div>
+            </div>
+        </div>
+    );
+});
+
+ModalContent.displayName = 'ModalContent';
+
+export const LifestealBreakdownModal = memo(({ isOpen, onClose, stats, profile, variant }: LifestealBreakdownModalProps) => {
+    if (!isOpen) return null;
+
+    return createPortal(
+        <ModalContent
+            stats={stats}
+            profile={profile}
+            onClose={onClose}
+            variant={variant}
+        />,
+        document.body
+    );
+});

--- a/src/components/Profile/LoadoutComparisonModal.tsx
+++ b/src/components/Profile/LoadoutComparisonModal.tsx
@@ -1,0 +1,112 @@
+import { memo } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '../UI/Button';
+import { X, Zap, Heart, Swords, Shield, Star, TrendingUp, Crosshair, Activity } from 'lucide-react';
+import { formatNumber } from '../../utils/format';
+import { formatPercent, formatMultiplier } from '../../utils/statsCalculator';
+import { ComparisonStatRow } from './StatsSummaryPanel';
+import { ExpandedLoadout } from '../../hooks/useLoadoutSweep';
+
+interface LoadoutComparisonModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    current: ExpandedLoadout;
+    proposed: ExpandedLoadout;
+}
+
+const ModalContent = memo(({ current, proposed, onClose }: Omit<LoadoutComparisonModalProps, 'isOpen'>) => {
+    const cur = current.calcStats;
+    const pro = proposed.calcStats;
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/85 backdrop-blur-[2px] p-2 md:p-4" onClick={onClose}>
+            <div
+                className="bg-bg-primary w-full max-w-[calc(100vw-1rem)] md:max-w-xl max-h-[95vh] rounded-2xl border border-border/60 shadow-2xl flex flex-col overflow-hidden animate-in zoom-in-95 fade-in duration-200"
+                onClick={e => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-center justify-between p-4 md:p-5 border-b border-border bg-bg-secondary/40">
+                    <h3 className="text-xl md:text-2xl font-bold text-white tracking-tight">Current &rarr; Proposed</h3>
+                    <button onClick={onClose} className="p-2 hover:bg-white/10 rounded-full transition-all text-white/60 hover:text-white">
+                        <X className="w-5 h-5" />
+                    </button>
+                </div>
+
+                {/* Content */}
+                <div className="flex-1 overflow-y-auto p-4 md:p-5 space-y-2 custom-scrollbar">
+                    {/* Headline metrics */}
+                    <ComparisonStatRow variant="minimal" icon={<Zap className="w-4 h-4" />} label="DPS"
+                        originalValue={current.dps} testValue={proposed.dps}
+                        formatFn={formatNumber} color="text-orange-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Heart className="w-4 h-4" />} label="Lifesteal/sec"
+                        originalValue={current.lifestealPerSec} testValue={proposed.lifestealPerSec}
+                        formatFn={formatNumber} color="text-purple-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Activity className="w-4 h-4" />} label="HPS"
+                        originalValue={current.healPerSec} testValue={proposed.healPerSec}
+                        formatFn={formatNumber} color="text-emerald-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Swords className="w-4 h-4" />} label="Shown Dmg"
+                        originalValue={current.shownDmg} testValue={proposed.shownDmg}
+                        formatFn={formatNumber} color="text-red-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Swords className="w-4 h-4" />} label="Calculated Dmg"
+                        originalValue={current.calcDmg} testValue={proposed.calcDmg}
+                        formatFn={formatNumber} color="text-red-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Heart className="w-4 h-4" />} label="Shown HP"
+                        originalValue={current.shownHp} testValue={proposed.shownHp}
+                        formatFn={formatNumber} color="text-green-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Heart className="w-4 h-4" />} label="Calculated HP"
+                        originalValue={current.calcHp} testValue={proposed.calcHp}
+                        formatFn={formatNumber} color="text-green-400" />
+
+                    <div className="h-px bg-border my-3" />
+
+                    {/* Underlying stats */}
+                    <ComparisonStatRow variant="minimal" icon={<Star className="w-4 h-4" />} label="Crit chance"
+                        originalValue={cur.criticalChance || 0} testValue={pro.criticalChance || 0}
+                        formatFn={formatPercent} color="text-yellow-400" />
+                    <ComparisonStatRow variant="minimal" icon={<TrendingUp className="w-4 h-4" />} label="Crit damage"
+                        originalValue={cur.criticalDamage || 0} testValue={pro.criticalDamage || 0}
+                        formatFn={formatMultiplier} color="text-yellow-500" />
+                    <ComparisonStatRow variant="minimal" icon={<Heart className="w-4 h-4" />} label="Lifesteal"
+                        originalValue={cur.lifeSteal || 0} testValue={pro.lifeSteal || 0}
+                        formatFn={formatPercent} color="text-purple-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Zap className="w-4 h-4" />} label="Double chance"
+                        originalValue={cur.doubleDamageChance || 0} testValue={pro.doubleDamageChance || 0}
+                        formatFn={formatPercent} color="text-purple-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Shield className="w-4 h-4" />} label="Block chance"
+                        originalValue={cur.blockChance || 0} testValue={pro.blockChance || 0}
+                        formatFn={formatPercent} color="text-blue-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Swords className="w-4 h-4" />} label="Damage"
+                        originalValue={cur.secondaryDamageMulti || 0} testValue={pro.secondaryDamageMulti || 0}
+                        formatFn={formatPercent} color="text-red-400" />
+                    <ComparisonStatRow variant="minimal" icon={<Crosshair className="w-4 h-4" />} label="Ranged Dmg"
+                        originalValue={cur.rangedDamageMultiplier || 0} testValue={pro.rangedDamageMultiplier || 0}
+                        formatFn={formatPercent} color="text-sky-400" />
+                    <ComparisonStatRow variant="minimal" icon={<TrendingUp className="w-4 h-4" />} label="Attack speed"
+                        originalValue={cur.attackSpeedMultiplier || 0} testValue={pro.attackSpeedMultiplier || 0}
+                        formatFn={formatMultiplier} color="text-orange-400" />
+                    <ComparisonStatRow variant="minimal" icon={<TrendingUp className="w-4 h-4" />} label="Skill cooldown"
+                        originalValue={cur.skillCooldownReduction || 0} testValue={pro.skillCooldownReduction || 0}
+                        formatFn={formatPercent} color="text-emerald-400" />
+                </div>
+
+                {/* Footer */}
+                <div className="p-4 border-t border-border bg-bg-secondary flex justify-end">
+                    <Button onClick={onClose} variant="ghost" className="px-8 text-accent-primary hover:text-accent-primary">Close</Button>
+                </div>
+            </div>
+        </div>
+    );
+});
+
+ModalContent.displayName = 'LoadoutComparisonModalContent';
+
+export const LoadoutComparisonModal = memo(({ isOpen, onClose, current, proposed }: LoadoutComparisonModalProps) => {
+    if (!isOpen) return null;
+
+    return createPortal(
+        <ModalContent current={current} proposed={proposed} onClose={onClose} />,
+        document.body
+    );
+});
+
+LoadoutComparisonModal.displayName = 'LoadoutComparisonModal';

--- a/src/components/Profile/PetPanel.tsx
+++ b/src/components/Profile/PetPanel.tsx
@@ -2,9 +2,9 @@ import { useProfile } from '../../context/ProfileContext';
 import { useComparison } from '../../context/ComparisonContext';
 import { useGameDataContext } from '../../context/GameDataContext';
 import { Card } from '../UI/Card';
-import { Zap as PowerIcon, Plus, Cat, Sword, RotateCcw } from 'lucide-react';
+import { Zap as PowerIcon, Plus, Cat, Sword, RotateCcw, Heart } from 'lucide-react';
 import { Button } from '../UI/Button';
-import { PetSlot } from '../../types/Profile';
+import { PetSlot, MountSlot } from '../../types/Profile';
 import { useState, useMemo } from 'react';
 import { cn } from '../../lib/utils';
 import { MAX_ACTIVE_PETS } from '../../utils/constants';
@@ -40,7 +40,7 @@ export function PetPanel({ variant = 'default', title, comparePets }: PetPanelPr
         updateTestPetAscension,
         isCompactStats
     } = useComparison();
-    const { optimizePets, isReady } = useProfileOptimizer();
+    const { optimizeLoadout, isReady } = useProfileOptimizer();
     
     const activePets = useMemo(() => {
         if (variant === 'original' && originalPets) return originalPets;
@@ -60,6 +60,8 @@ export function PetPanel({ variant = 'default', title, comparePets }: PetPanelPr
     const [editingPetIdx, setEditingPetIdx] = useState<number | null>(null);
     const [petToSave, setPetToSave] = useState<PetSlot | null>(null);
     const [previousPets, setPreviousPets] = useState<PetSlot[] | null>(null);
+    // undefined = nothing to revert; null = revert to "no mount equipped"
+    const [previousMount, setPreviousMount] = useState<MountSlot | null | undefined>(undefined);
 
     const { data: petLibrary } = useGameData<any>('PetLibrary.json');
     const { data: petBalancing } = useGameData<any>('PetBalancingLibrary.json');
@@ -210,16 +212,29 @@ export function PetPanel({ variant = 'default', title, comparePets }: PetPanelPr
         }
     };
 
-    const handleAutoOptimize = (metric: 'dps' | 'power') => {
+    // Optimizer searches saved pets AND saved mounts, so enable when either pool has entries.
+    const autoDisabled = (profile.pets.savedBuilds?.length || 0) < 1 && (profile.mount.savedBuilds?.length || 0) < 1;
+
+    const handleAutoOptimize = (metric: 'dps' | 'power' | 'lifesteal') => {
         setPreviousPets([...activePets]);
-        const best = optimizePets(metric);
-        if (best) updatePets(best);
+        if (variant === 'default') setPreviousMount(profile.mount.active);
+
+        const best = optimizeLoadout(metric);
+        if (!best) return;
+
+        updatePets(best.pets);
+        // Mount is a single global slot with no per-variant override, so only apply in default.
+        if (variant === 'default') updateNestedProfile('mount', { active: best.mount });
     };
 
     const handleRevert = () => {
         if (previousPets) {
             updatePets(previousPets);
             setPreviousPets(null);
+        }
+        if (previousMount !== undefined) {
+            updateNestedProfile('mount', { active: previousMount });
+            setPreviousMount(undefined);
         }
     };
 
@@ -327,29 +342,40 @@ export function PetPanel({ variant = 'default', title, comparePets }: PetPanelPr
                     </h2>
                     
                     <div className="flex items-center gap-1.5 flex-wrap">
-                        <Button 
-                            variant="outline" 
-                            size="sm" 
+                        <Button
+                            variant="outline"
+                            size="sm"
                             className="h-7 px-2 text-[10px] font-bold border-red-500/20 hover:bg-red-500/10 hover:border-red-500/40 text-red-400 gap-1 active:scale-95 transition-all w-fit"
                             onClick={() => handleAutoOptimize('dps')}
-                            disabled={!isReady || (profile.pets.savedBuilds?.length || 0) < 1}
-                            title="Select best 3 saved pets for Max DPS"
+                            disabled={!isReady || autoDisabled}
+                            title="Select best 3 pets + mount for Max DPS"
                         >
                             <Sword className="w-3 h-3" />
                             AUTO DPS
                         </Button>
-                        <Button 
-                            variant="outline" 
-                            size="sm" 
+                        <Button
+                            variant="outline"
+                            size="sm"
                             className="h-7 px-2 text-[10px] font-bold border-amber-500/20 hover:bg-amber-500/10 hover:border-amber-500/40 text-amber-500 gap-1 active:scale-95 transition-all w-fit"
                             onClick={() => handleAutoOptimize('power')}
-                            disabled={!isReady || (profile.pets.savedBuilds?.length || 0) < 1}
-                            title="Select best 3 saved pets for Max Power"
+                            disabled={!isReady || autoDisabled}
+                            title="Select best 3 pets + mount for Max Power"
                         >
                             <PowerIcon className="w-3 h-3" />
                             AUTO POWER
                         </Button>
-                        {previousPets && (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 px-2 text-[10px] font-bold border-purple-500/20 hover:bg-purple-500/10 hover:border-purple-500/40 text-purple-400 gap-1 active:scale-95 transition-all w-fit"
+                            onClick={() => handleAutoOptimize('lifesteal')}
+                            disabled={!isReady || autoDisabled}
+                            title="Select best 3 pets + mount for Max Lifesteal/sec"
+                        >
+                            <Heart className="w-3 h-3" />
+                            AUTO LIFESTEAL/SEC
+                        </Button>
+                        {(previousPets || previousMount !== undefined) && (
                             <Button 
                                 variant="ghost" 
                                 size="sm" 

--- a/src/components/Profile/StatSourcesModal.tsx
+++ b/src/components/Profile/StatSourcesModal.tsx
@@ -1,0 +1,279 @@
+import { memo, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Cat, Info } from 'lucide-react';
+import { Button } from '../UI/Button';
+import { ItemSelectionCard } from '../UI/ItemSelectionCard';
+import { SpriteSheetIcon } from '../UI/SpriteSheetIcon';
+import { cn } from '../../lib/utils';
+import { AGES } from '../../utils/constants';
+import { getItemImage } from '../../utils/itemAssets';
+import { getAscensionTexturePath } from '../../utils/ascensionUtils';
+import { useGameData } from '../../hooks/useGameData';
+import { useGameDataContext } from '../../context/GameDataContext';
+import { AggregatedStats } from '../../utils/statEngine';
+import { StatContribution, SourceKind, isTotalKey } from '../../types/statAttribution';
+
+const SLOT_TO_FILE_MAP: Record<string, string> = {
+    Weapon: 'Weapon', Helmet: 'Headgear', Body: 'Armor', Gloves: 'Glove',
+    Belt: 'Belt', Necklace: 'Neck', Ring: 'Ring', Shoe: 'Foot',
+};
+
+const SLOT_TYPE_ID_MAP: Record<string, number> = {
+    Helmet: 0, Body: 1, Gloves: 2, Necklace: 3, Ring: 4, Weapon: 5, Shoe: 6, Belt: 7,
+};
+
+// Text-line sources render grouped in this order
+const KIND_ORDER: SourceKind[] = ['base', 'tech', 'ascension', 'skin', 'set', 'skill'];
+
+const KIND_LABEL: Record<string, string> = {
+    base: 'Base', tech: 'Tree', ascension: 'Asc',
+    skin: 'Skins', set: 'Sets', skill: 'Skills',
+};
+
+/** Mirrors the multiplier breakdown the character-stat card shows in its subtitle */
+export interface MultiplierBreakdown {
+    label: string;                                  // e.g. 'Damage Multiplier'
+    total: string;                                  // e.g. '110%'
+    parts: { label: string; value: string }[];      // Items / Tree / Asc / Skins / Sets
+}
+
+export interface StatSourcesModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    statKey: string | null;
+    label: string;
+    /** Pre-formatted total, taken straight from the card that opened this modal */
+    totalDisplay: string;
+    stats: AggregatedStats;
+    /** How to format an individual contribution (percent stats vs flat damage/health) */
+    formatValue: (value: number) => string;
+    /** For the total stats: the card's own multiplier breakdown, so numbers match the card */
+    multiplier?: MultiplierBreakdown;
+}
+
+const ModalContent = memo(({ statKey, label, totalDisplay, stats, formatValue, multiplier, onClose }: Omit<StatSourcesModalProps, 'isOpen'>) => {
+    const { selectedVersion } = useGameDataContext();
+    const { data: autoMapping } = useGameData<any>('AutoItemMapping.json');
+    const { data: spriteMapping } = useGameData<any>('ManualSpriteMapping.json');
+
+    const entries: StatContribution[] = useMemo(() => {
+        if (!statKey) return [];
+        return stats.attribution?.byStat?.[statKey] ?? [];
+    }, [statKey, stats]);
+
+    const isTotal = !!statKey && isTotalKey(statKey);
+
+    // Flat contributors: items/pets/mount as cards, base/skills as text lines.
+    // The multiplier portion comes from the card's own breakdown (the `multiplier` prop),
+    // not from summing here - so the modal matches the character-stat card by construction.
+    const cards = useMemo(
+        () => entries.filter(e => e.ref && e.op === 'add').sort((a, b) => b.value - a.value),
+        [entries]
+    );
+    const addLines = useMemo(
+        () => entries.filter(e => !e.ref && e.op === 'add').sort((a, b) => b.value - a.value),
+        [entries]
+    );
+
+    const renderCard = (c: StatContribution) => {
+        const ref = c.ref!;
+        const contribution = (
+            <div className="text-[11px] font-mono font-bold text-accent-primary text-center py-1">
+                +{formatValue(c.value)}
+            </div>
+        );
+
+        if (ref.kind === 'item') {
+            const item = ref.item;
+            const ageName = AGES[item.age] || 'Primitive';
+            const fileSlot = SLOT_TO_FILE_MAP[ref.slot] || ref.slot;
+            const typeId = SLOT_TYPE_ID_MAP[ref.slot];
+            const nameKey = typeId !== undefined ? `${item.age}_${typeId}_${item.idx}` : '';
+            return (
+                <ItemSelectionCard
+                    key={c.id}
+                    item={item}
+                    slotKey={ref.slot}
+                    slotLabel={ref.slot}
+                    itemName={autoMapping?.[nameKey]?.ItemName || ref.slot}
+                    itemImage={getItemImage(ageName, fileSlot, item.idx, autoMapping, selectedVersion)}
+                    variant="compact"
+                    currentLevel={item.level}
+                    customStats={contribution}
+                />
+            );
+        }
+
+        if (ref.kind === 'pet') {
+            const pet = ref.pet;
+            const spriteEntry = spriteMapping?.pets?.mapping
+                ? Object.entries(spriteMapping.pets.mapping).find(
+                    ([, v]: [string, any]) => v.id === pet.id && v.rarity === pet.rarity)
+                : undefined;
+            const spriteInfo = spriteEntry
+                ? { spriteIndex: parseInt(spriteEntry[0]), config: spriteMapping.pets, name: (spriteEntry[1] as any).name }
+                : null;
+            return (
+                <ItemSelectionCard
+                    key={c.id}
+                    item={pet}
+                    slotKey={`pet-${ref.index}`}
+                    slotLabel={`Pet ${ref.index + 1}`}
+                    itemName={pet.customName || spriteInfo?.name || `${pet.rarity} Pet`}
+                    itemImage={null}
+                    rarity={pet.rarity}
+                    hideAgeStyles
+                    variant="compact"
+                    currentLevel={pet.level}
+                    spriteMapping={spriteMapping}
+                    customStats={contribution}
+                    renderIcon={() => spriteInfo ? (
+                        <SpriteSheetIcon
+                            textureSrc={getAscensionTexturePath('Pets', pet.ascensionLevel || 0, selectedVersion)}
+                            spriteWidth={spriteInfo.config.sprite_size.width}
+                            spriteHeight={spriteInfo.config.sprite_size.height}
+                            sheetWidth={spriteInfo.config.texture_size.width}
+                            sheetHeight={spriteInfo.config.texture_size.height}
+                            iconIndex={spriteInfo.spriteIndex}
+                            className="w-10 h-10"
+                        />
+                    ) : (
+                        <Cat className={cn('w-8 h-8 opacity-50', `text-rarity-${pet.rarity.toLowerCase()}`)} />
+                    )}
+                />
+            );
+        }
+
+        const mount = ref.mount;
+        return (
+            <ItemSelectionCard
+                key={c.id}
+                item={mount}
+                slotKey="mount"
+                slotLabel="Mount"
+                itemName={mount.customName || `${mount.rarity} Mount`}
+                itemImage={null}
+                rarity={mount.rarity}
+                hideAgeStyles
+                variant="compact"
+                currentLevel={mount.level}
+                spriteMapping={spriteMapping}
+                customStats={contribution}
+            />
+        );
+    };
+
+    const renderTextLine = (c: StatContribution) => (
+        <div key={c.id} className="flex items-center justify-between gap-3 px-3 py-2 bg-bg-input/30 rounded-lg border border-border/30">
+            <div className="min-w-0">
+                <div className="text-sm text-text-primary truncate">{c.label}</div>
+                {c.detail && <div className="text-[11px] text-text-muted truncate">{c.detail}</div>}
+            </div>
+            <div className="font-mono font-bold text-sm text-accent-primary shrink-0">
+                +{formatValue(c.value)}
+            </div>
+        </div>
+    );
+
+    const groupedAddLines = KIND_ORDER
+        .map(kind => ({ kind, items: addLines.filter(l => l.kind === kind) }))
+        .filter(g => g.items.length > 0);
+
+    const hasAnything = entries.length > 0;
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/85 backdrop-blur-[2px] p-2 md:p-4" onClick={onClose}>
+            <div
+                className={cn(
+                    'bg-bg-primary w-full max-w-[calc(100vw-1rem)] max-h-[95vh] rounded-2xl border border-border/60 shadow-2xl flex flex-col overflow-hidden animate-in zoom-in-95 fade-in duration-200',
+                    isTotal ? 'md:max-w-2xl' : 'md:max-w-xl'
+                )}
+                onClick={e => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-center justify-between p-4 md:p-5 border-b border-border bg-bg-secondary/40">
+                    <div className="min-w-0">
+                        <h3 className="text-xl md:text-2xl font-bold text-white tracking-tight truncate">{label}</h3>
+                        <div className="text-sm text-text-muted">
+                            Total <span className="font-mono font-bold text-accent-primary">{totalDisplay}</span>
+                        </div>
+                    </div>
+                    <button onClick={onClose} className="p-2 hover:bg-white/10 rounded-full transition-all text-white/60 hover:text-white shrink-0">
+                        <X className="w-5 h-5" />
+                    </button>
+                </div>
+
+                {/* Content */}
+                <div className="flex-1 overflow-y-auto p-4 md:p-5 space-y-4 custom-scrollbar">
+                    {!hasAnything && (
+                        <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
+                            <Info className="w-8 h-8 text-text-muted opacity-50" />
+                            <div className="text-sm text-text-muted">Nothing is contributing to this stat yet.</div>
+                        </div>
+                    )}
+
+                    {cards.length > 0 && (
+                        <div>
+                            <div className="text-xs font-bold uppercase text-text-muted mb-2">
+                                {isTotal ? 'Flat contributors' : 'Equipment, pets & mount'}
+                            </div>
+                            {/* Cards are display-only here: suppress ItemSelectionCard's hover/click affordance */}
+                            <div className="grid grid-cols-2 md:grid-cols-3 gap-2 pointer-events-none">
+                                {cards.map(renderCard)}
+                            </div>
+                        </div>
+                    )}
+
+                    {groupedAddLines.map(group => (
+                        <div key={group.kind}>
+                            <div className="text-xs font-bold uppercase text-text-muted mb-2">{KIND_LABEL[group.kind] || group.kind}</div>
+                            <div className="space-y-1.5">{group.items.map(l => renderTextLine(l))}</div>
+                        </div>
+                    ))}
+
+                    {/* Multiplier breakdown, mirroring the character-stat card's own subtitle */}
+                    {multiplier && (
+                        <div>
+                            <div className="flex items-center justify-between mb-2">
+                                <div className="text-xs font-bold uppercase text-text-muted">{multiplier.label}</div>
+                                <div className="font-mono font-bold text-sm text-accent-primary">{multiplier.total}</div>
+                            </div>
+                            <div className="space-y-1.5">
+                                {multiplier.parts.length > 0 ? multiplier.parts.map(p => (
+                                    <div key={p.label} className="flex items-center justify-between gap-3 px-3 py-2 bg-bg-input/30 rounded-lg border border-border/30">
+                                        <span className="text-sm text-text-primary">{p.label}</span>
+                                        <span className="font-mono font-bold text-sm text-accent-primary">{p.value}</span>
+                                    </div>
+                                )) : (
+                                    <div className="text-sm text-text-muted px-3 py-2">No bonus multipliers &mdash; base only</div>
+                                )}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Additive stats reconcile exactly: show the running total */}
+                    {!isTotal && hasAnything && (
+                        <div className="pt-3 border-t border-border flex items-center justify-between text-sm">
+                            <span className="text-text-muted">Total</span>
+                            <span className="font-mono font-bold text-accent-primary">{totalDisplay}</span>
+                        </div>
+                    )}
+                </div>
+
+                {/* Footer */}
+                <div className="p-4 border-t border-border bg-bg-secondary flex justify-end">
+                    <Button onClick={onClose} variant="ghost" className="px-8 text-accent-primary hover:text-accent-primary">Close</Button>
+                </div>
+            </div>
+        </div>
+    );
+});
+
+ModalContent.displayName = 'StatSourcesModalContent';
+
+export const StatSourcesModal = memo(({ isOpen, ...rest }: StatSourcesModalProps) => {
+    if (!isOpen || !rest.statKey) return null;
+    return createPortal(<ModalContent {...rest} />, document.body);
+});
+
+StatSourcesModal.displayName = 'StatSourcesModal';

--- a/src/components/Profile/StatsSummaryPanel.tsx
+++ b/src/components/Profile/StatsSummaryPanel.tsx
@@ -4,7 +4,7 @@ import {
     Swords, Heart, Shield, Zap, Target, Gauge,
     TrendingUp, Clock, Coins, Star, Crosshair, TreeDeciduous, Sparkles,
     ArrowUp, ArrowDown, X, Check, ArrowRight, Hash, Minimize2, Layout, Download,
-    ArrowLeftRight, Info
+    ArrowLeftRight, Info, Scale
 } from 'lucide-react';
 import { Button } from '../UI/Button';
 import { AnimatedClock } from '../UI/AnimatedClock';
@@ -15,6 +15,7 @@ import { useGlobalStats } from '../../hooks/useGlobalStats';
 import { useTreeModifiers } from '../../hooks/useCalculatedStats';
 import { getStatName } from '../../utils/statNames';
 import { useComparison } from '../../context/ComparisonContext';
+import { useLoadoutSweep } from '../../hooks/useLoadoutSweep';
 import { useProfile } from '../../context/ProfileContext';
 import { useGameData } from '../../hooks/useGameData';
 import { calculateStats, LibraryData, AggregatedStats } from '../../utils/statEngine';
@@ -438,11 +439,17 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
         keepOriginal,
         applyTestBuild,
         loadProfileIntoTest,
+        updateTestPet,
+        updateTestMount,
         isCompactStats,
         setIsCompactStats,
         excludeSubstats,
         setExcludeSubstats
     } = useComparison();
+    // Same balanced principle as the Loadout Optimizer: sweep the saved pet+mount
+    // builds and rank by 0.5·DPS + 0.5·HPS (each normalised across the sweep).
+    // Only runs while comparing so it adds no background cost to the normal panel.
+    const { status: sweepStatus, rank: rankLoadout } = useLoadoutSweep(isComparing);
     const stats = useGlobalStats(excludeSubstats);
     const fullStats = useGlobalStats(false);
     const techModifiers = useTreeModifiers() as Record<string, number>;
@@ -704,6 +711,16 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
     const formatValue = (val: number) => isCompactStats
         ? formatCompactNumber(val)
         : val.toLocaleString(undefined, { maximumFractionDigits: 0 });
+
+    // "Auto Balanced": load the balanced-best pet+mount loadout (from the saved
+    // builds) into the test side, using the Loadout Optimizer's scoring verbatim.
+    const autoBalancedReady = sweepStatus === 'done';
+    const applyAutoBalanced = () => {
+        const best = rankLoadout('balanced')[0]?.result;
+        if (!best) return;
+        updateTestPet(best.petSet);
+        updateTestMount(best.mount);
+    };
 
     // The comparison UI block
     // The comparison UI block
@@ -1094,6 +1111,8 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                 <ComparisonStatRow isCompact={isCompactStats} variant="minimal" icon={<Zap className="w-4 h-4 text-orange-400" />} label="Theo DPS" originalValue={originalDps} testValue={testDps} color="text-orange-400" onTestDetailsClick={() => { if (testStats && testProfile) { setModalData({ stats: testStats, profile: testProfile, variant: 'test' }); setShowDpsModal(true); } }} />
                                 <div className="w-px h-6 bg-white/10" />
                                 <ComparisonStatRow isCompact={isCompactStats} variant="minimal" icon={<TrendingUp className="w-4 h-4 text-emerald-400" />} label="Theo HPS" originalValue={originalHps} testValue={testHps} color="text-emerald-400" />
+                                <div className="w-px h-6 bg-white/10" />
+                                <ComparisonStatRow isCompact={isCompactStats} variant="minimal" icon={<Heart className="w-4 h-4 text-purple-400" />} label="Theo LS/s" originalValue={originalHpsDetails.lifesteal} testValue={testHpsDetails.lifesteal} color="text-purple-400" onOriginalDetailsClick={() => { if (originalFullStats && originalProfile) { openLifestealModal(originalFullStats, originalProfile, 'original'); } }} onTestDetailsClick={() => { if (testFullStats && testProfile) { openLifestealModal(testFullStats, testProfile, 'test'); } }} />
                             </div>
 
                             {/* Grouped Real-Time */}
@@ -1101,6 +1120,8 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                 <ComparisonStatRow isCompact={isCompactStats} variant="minimal" icon={<Zap className="w-4 h-4 text-orange-500" />} label="Real DPS" originalValue={originalDpsDetails.realTotal} testValue={testDpsDetails.realTotal} color="text-orange-500" onTestDetailsClick={() => { if (testStats && testProfile) { setModalData({ stats: testStats, profile: testProfile, variant: 'test' }); setShowDpsModal(true); } }} />
                                 <div className="w-px h-6 bg-orange-500/10" />
                                 <ComparisonStatRow isCompact={isCompactStats} variant="minimal" icon={<TrendingUp className="w-4 h-4 text-emerald-500" />} label="Real HPS" originalValue={originalRealHps} testValue={testRealHps} color="text-emerald-500" />
+                                <div className="w-px h-6 bg-orange-500/10" />
+                                <ComparisonStatRow isCompact={isCompactStats} variant="minimal" icon={<Heart className="w-4 h-4 text-purple-500" />} label="Real LS/s" originalValue={originalRealHpsDetails.lifesteal} testValue={testRealHpsDetails.lifesteal} color="text-purple-500" onOriginalDetailsClick={() => { if (originalFullStats && originalProfile) { openLifestealModal(originalFullStats, originalProfile, 'original'); } }} onTestDetailsClick={() => { if (testFullStats && testProfile) { openLifestealModal(testFullStats, testProfile, 'test'); } }} />
                             </div>
                         </>
                     ) : viewTab === 'passives' ? (
@@ -1196,6 +1217,17 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                             </select>
                         </div>
                     )}
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={applyAutoBalanced}
+                        disabled={!autoBalancedReady}
+                        title="Fill the test build with the balanced-best pet + mount loadout from your saved builds (same scoring as the Loadout Optimizer)"
+                        className="h-8 sm:h-10 px-2 flex flex-col items-center justify-center p-0 gap-0.5 text-[9px] text-violet-400/70 hover:text-violet-400 hover:bg-violet-500/10 border border-transparent hover:border-violet-500/20 transition-all font-bold uppercase tracking-tight disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                        <Scale className={cn("w-3.5 h-3.5", !autoBalancedReady && "animate-pulse")} />
+                        <span>Auto Bal</span>
+                    </Button>
                     <Button variant="ghost" size="sm" onClick={exitCompareMode} className="h-8 sm:h-10 px-2 sm:px-6 gap-1 sm:gap-2 text-[10px] sm:text-xs text-text-muted hover:text-red-400 hover:bg-red-500/10 border border-transparent hover:border-red-500/20 transition-all font-bold">
                         <X className="w-3.5 h-3.5 sm:w-4 h-4" />
                         <span className="hidden sm:inline">Exit Comparison</span>
@@ -1353,7 +1385,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                     <div className="mt-4 pt-4 border-t border-border/30 space-y-4">
                         <div className="space-y-3">
                             <div className="text-[10px] text-text-muted text-center font-bold uppercase tracking-widest opacity-60">Build Actions</div>
-                            <div className="grid grid-cols-4 gap-2">
+                            <div className="grid grid-cols-2 gap-2">
                                 {/* Load Profile - Small Button with hidden select */}
                                 {profiles.length > 1 && (
                                     <div className="relative">
@@ -1386,6 +1418,17 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                 <Button
                                     variant="ghost"
                                     size="sm"
+                                    onClick={applyAutoBalanced}
+                                    disabled={!autoBalancedReady}
+                                    title="Fill the test build with the balanced-best pet + mount loadout from your saved builds (same scoring as the Loadout Optimizer)"
+                                    className="h-10 flex flex-col items-center justify-center p-0 gap-1 text-[10px] text-violet-400/70 hover:text-violet-400 grayscale hover:grayscale-0 transition-all font-bold uppercase tracking-tight border border-transparent hover:border-violet-500/20 bg-violet-500/5 disabled:opacity-40 disabled:cursor-not-allowed"
+                                >
+                                    <Scale className={cn("w-4 h-4", !autoBalancedReady && "animate-pulse")} />
+                                    <span>Auto Balanced</span>
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
                                     onClick={exitCompareMode}
                                     className="h-10 flex flex-col items-center justify-center p-0 gap-1 text-[10px] text-text-muted hover:text-red-400 grayscale hover:grayscale-0 transition-all font-bold uppercase tracking-tight border border-transparent hover:border-red-500/20"
                                 >
@@ -1405,7 +1448,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                     variant="primary"
                                     size="sm"
                                     onClick={applyTestBuild}
-                                    className="h-10 flex flex-col items-center justify-center p-0 gap-1 text-[10px] font-bold uppercase tracking-tight bg-accent-primary shadow-lg shadow-accent-primary/10 hover:scale-105 transition-transform"
+                                    className="col-span-2 h-10 flex flex-col items-center justify-center p-0 gap-1 text-[10px] font-bold uppercase tracking-tight bg-accent-primary shadow-lg shadow-accent-primary/10 hover:scale-105 transition-transform"
                                 >
                                     <ArrowRight className="w-4 h-4" />
                                     <span>Apply Test</span>

--- a/src/components/Profile/StatsSummaryPanel.tsx
+++ b/src/components/Profile/StatsSummaryPanel.tsx
@@ -4,7 +4,7 @@ import {
     Swords, Heart, Shield, Zap, Target, Gauge,
     TrendingUp, Clock, Coins, Star, Crosshair, TreeDeciduous, Sparkles,
     ArrowUp, ArrowDown, X, Check, ArrowRight, Hash, Minimize2, Layout, Download,
-    ArrowLeftRight
+    ArrowLeftRight, Info
 } from 'lucide-react';
 import { Button } from '../UI/Button';
 import { AnimatedClock } from '../UI/AnimatedClock';
@@ -21,6 +21,9 @@ import { calculateStats, LibraryData, AggregatedStats } from '../../utils/statEn
 import { useTreeMode } from '../../context/TreeModeContext';
 import { UserProfile } from '../../types/Profile';
 import { DpsBreakdownModal } from './DpsBreakdownModal';
+import { LifestealBreakdownModal } from './LifestealBreakdownModal';
+import { StatSourcesModal, MultiplierBreakdown } from './StatSourcesModal';
+import { TOTAL_DAMAGE_KEY, TOTAL_HEALTH_KEY, TOTAL_POWER_KEY } from '../../types/statAttribution';
 
 interface StatRowProps {
     icon: React.ReactNode;
@@ -31,9 +34,29 @@ interface StatRowProps {
     perf?: number;
     color?: string;
     onInfoPointsClick?: () => void;
+    /** Opens the per-source breakdown modal. Distinct from onInfoPointsClick's DETAILS pill. */
+    onInfoClick?: () => void;
 }
 
-function StatRow({ icon, label, value, subValue, count, perf, color = 'text-accent-primary', onInfoPointsClick }: StatRowProps) {
+// Small neutral "i" that opens the stat's source breakdown
+function InfoDot({ onClick, className }: { onClick: () => void; className?: string }) {
+    return (
+        <button
+            onClick={(e) => { e.stopPropagation(); onClick(); }}
+            className={cn(
+                "w-4 h-4 rounded-full border border-border/60 bg-bg-secondary/80 flex items-center justify-center",
+                "text-text-muted hover:text-accent-primary hover:border-accent-primary/50 transition-colors active:scale-95 shrink-0",
+                className
+            )}
+            title="Show stat sources"
+            aria-label="Show stat sources"
+        >
+            <Info className="w-2.5 h-2.5" />
+        </button>
+    );
+}
+
+function StatRow({ icon, label, value, subValue, count, perf, color = 'text-accent-primary', onInfoPointsClick, onInfoClick }: StatRowProps) {
     return (
         <div className="flex flex-col justify-between p-2.5 bg-bg-input/30 rounded-lg border border-border/30 hover:bg-bg-input/50 transition-colors min-h-[5rem]">
             <div className="flex items-center gap-2 w-full">
@@ -43,6 +66,7 @@ function StatRow({ icon, label, value, subValue, count, perf, color = 'text-acce
                 <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5 flex-wrap">
                         <div className="text-sm font-medium text-text-primary leading-tight break-words">{label}</div>
+                        {onInfoClick && <InfoDot onClick={onInfoClick} />}
                         {onInfoPointsClick && (
                             <button
                                 onClick={(e) => {
@@ -76,10 +100,11 @@ function StatRow({ icon, label, value, subValue, count, perf, color = 'text-acce
 }
 
 // Compact stat for grid layouts
-function CompactStat({ icon, label, value, subValue, count, perf, color = 'text-accent-primary' }: StatRowProps) {
+function CompactStat({ icon, label, value, subValue, count, perf, color = 'text-accent-primary', onInfoClick }: StatRowProps) {
     return (
-        <div className="flex flex-col justify-between p-2.5 bg-bg-input/30 rounded-lg border border-border/30 hover:bg-bg-input/50 transition-colors min-h-[4.5rem]">
-            <div className="flex items-center gap-1.5 mb-1 min-w-0">
+        <div className="relative flex flex-col justify-between p-2.5 bg-bg-input/30 rounded-lg border border-border/30 hover:bg-bg-input/50 transition-colors min-h-[4.5rem]">
+            {onInfoClick && <InfoDot onClick={onInfoClick} className="absolute top-1 right-1" />}
+            <div className="flex items-center gap-1.5 mb-1 min-w-0 pr-4">
                 <div className={cn("w-5 h-5 rounded flex items-center justify-center bg-bg-secondary shrink-0", color)}>
                     {icon}
                 </div>
@@ -153,7 +178,7 @@ function formatDelta(original: number, comparison: number, isCompact: boolean): 
     };
 }
 
-interface ComparisonStatRowProps {
+export interface ComparisonStatRowProps {
     icon: React.ReactNode;
     label: string;
     originalValue: number;
@@ -169,7 +194,7 @@ interface ComparisonStatRowProps {
     className?: string;
 }
 
-function ComparisonStatRow({
+export function ComparisonStatRow({
     icon,
     label,
     originalValue,
@@ -356,6 +381,37 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
         setModalData({ stats: s, profile: p, variant: v });
         setShowDpsModal(true);
     };
+
+    const [showLifestealModal, setShowLifestealModal] = useState(false);
+    const openLifestealModal = (s: AggregatedStats, p: UserProfile, v: 'default' | 'original' | 'test' = 'default') => {
+        setModalData({ stats: s, profile: p, variant: v });
+        setShowLifestealModal(true);
+    };
+    // Per-source breakdown modal: one piece of state shared by all 16 stat cards
+    const [sourceModal, setSourceModal] = useState<
+        { key: string; label: string; total: string; format: (v: number) => string; multiplier?: MultiplierBreakdown } | null
+    >(null);
+    const infoProps = (
+        key: string, label: string, total: string,
+        format: (v: number) => string = formatPercent,
+        multiplier?: MultiplierBreakdown
+    ) => ({
+        onInfoClick: () => setSourceModal({ key, label, total, format, multiplier })
+    });
+
+    // Builds the same multiplier breakdown the total cards show in their subtitle,
+    // so the modal's numbers match the card by construction (mirrors formatDetailedBreakdown).
+    const mulBreakdown = (label: string, totalMultiplier: number, b: any): MultiplierBreakdown => {
+        const parts: { label: string; value: string }[] = [];
+        if (b?.base > 0) parts.push({ label: 'Base', value: `+${formatPercent(b.base, 1)}` });
+        if (b?.substats > 0) parts.push({ label: 'Items', value: `+${formatPercent(b.substats, 1)}` });
+        if (b?.tree > 0) parts.push({ label: 'Tree', value: `+${formatPercent(b.tree, 1)}` });
+        if (b?.ascension > 0) parts.push({ label: 'Asc', value: `+${formatPercent(b.ascension, 1)}` });
+        if (b?.skins > 0) parts.push({ label: 'Skins', value: `+${formatPercent(b.skins, 1)}` });
+        if (b?.sets > 0) parts.push({ label: 'Sets', value: `+${formatPercent(b.sets, 1)}` });
+        return { label, total: formatPercent(totalMultiplier || 1, 0), parts };
+    };
+
     const [openSection, setOpenSection] = useState<string | null>(null);
     const [viewTab, setViewTab] = useState<'general' | 'metrics' | 'hits' | 'passives'>(defaultTab);
     const {
@@ -767,6 +823,24 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                     { label: 'Skills', value: testHpsDetails.skills }
                                 ]}
                             />
+                            <ComparisonStatRow
+                                isCompact={isCompactStats}
+                                icon={<Heart className="w-4 h-4 text-purple-400" />}
+                                label="Lifesteal/sec"
+                                originalValue={originalHpsDetails.lifesteal}
+                                testValue={testHpsDetails.lifesteal}
+                                color="text-purple-400"
+                                onOriginalDetailsClick={() => {
+                                    if (originalFullStats && originalProfile) {
+                                        openLifestealModal(originalFullStats, originalProfile, 'original');
+                                    }
+                                }}
+                                onTestDetailsClick={() => {
+                                    if (testFullStats && testProfile) {
+                                        openLifestealModal(testFullStats, testProfile, 'test');
+                                    }
+                                }}
+                            />
                         </div>
                     </div>
 
@@ -820,6 +894,24 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                     { label: 'Lifesteal', value: testRealHpsDetails.lifesteal },
                                     { label: 'Skills', value: testRealHpsDetails.skills }
                                 ]}
+                            />
+                            <ComparisonStatRow
+                                isCompact={isCompactStats}
+                                icon={<Heart className="w-4 h-4 text-purple-500" />}
+                                label="Lifesteal/sec"
+                                originalValue={originalRealHpsDetails.lifesteal}
+                                testValue={testRealHpsDetails.lifesteal}
+                                color="text-purple-500"
+                                onOriginalDetailsClick={() => {
+                                    if (originalFullStats && originalProfile) {
+                                        openLifestealModal(originalFullStats, originalProfile, 'original');
+                                    }
+                                }}
+                                onTestDetailsClick={() => {
+                                    if (testFullStats && testProfile) {
+                                        openLifestealModal(testFullStats, testProfile, 'test');
+                                    }
+                                }}
                             />
                         </div>
                     </div>
@@ -1122,13 +1214,20 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                 </div>
                 )}
 
-                <DpsBreakdownModal 
-                    isOpen={showDpsModal} 
-                    onClose={() => setShowDpsModal(false)} 
-                    stats={modalData?.stats || stats} 
-                    profile={modalData?.profile || profile} 
+                <DpsBreakdownModal
+                    isOpen={showDpsModal}
+                    onClose={() => setShowDpsModal(false)}
+                    stats={modalData?.stats || stats}
+                    profile={modalData?.profile || profile}
                     variant={modalData?.variant || 'default'}
-                    skillLibrary={skillLibrary} 
+                    skillLibrary={skillLibrary}
+                />
+                <LifestealBreakdownModal
+                    isOpen={showLifestealModal}
+                    onClose={() => setShowLifestealModal(false)}
+                    stats={modalData?.stats || stats}
+                    profile={modalData?.profile || profile}
+                    variant={modalData?.variant || 'default'}
                 />
             </div>
         );
@@ -1387,6 +1486,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                 label="Total Power"
                                 value={formatValue(stats.power)}
                                 color="text-purple-400"
+                                {...infoProps(TOTAL_POWER_KEY, 'Total Power', formatValue(stats.power), formatValue)}
                             />
                             {(() => {
                                 const formatDetailedBreakdown = (b: any) => {
@@ -1407,6 +1507,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                             value={formatValue(stats.totalDamage)}
                                             subValue={`${formatPercent(stats.damageMultiplier || 1, 0)} Total (${formatDetailedBreakdown(stats.damageBreakdown) || 'Base Only'})`}
                                             color="text-red-400"
+                                            {...infoProps(TOTAL_DAMAGE_KEY, 'Total Damage', formatValue(stats.totalDamage), formatValue, mulBreakdown('Damage Multiplier', stats.damageMultiplier, stats.damageBreakdown))}
                                         />
                                         <StatRow
                                             icon={<Heart className="w-4 h-4" />}
@@ -1414,6 +1515,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                             value={formatValue(stats.totalHealth)}
                                             subValue={`${formatPercent(stats.healthMultiplier || 1, 0)} Total (${formatDetailedBreakdown(stats.healthBreakdown) || 'Base Only'})`}
                                             color="text-green-400"
+                                            {...infoProps(TOTAL_HEALTH_KEY, 'Total Health', formatValue(stats.totalHealth), formatValue, mulBreakdown('Health Multiplier', stats.healthMultiplier, stats.healthBreakdown))}
                                         />
                                     </>
                                 );
@@ -1440,6 +1542,14 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                         subValue={`Regen: ${formatCompactNumber(currentHpsDetails.regen)}, LifeSteal: ${formatCompactNumber(currentHpsDetails.lifesteal)}, Skills: ${formatCompactNumber(currentHpsDetails.skills)}${currentHpsDetails.blockBenefit > 0 ? `, Block Benefit: +${formatCompactNumber(currentHpsDetails.blockBenefit)}` : ''}`}
                                         color="text-emerald-400"
                                     />
+                                    <StatRow
+                                        icon={<Heart className="w-4 h-4" />}
+                                        label="Lifesteal/sec"
+                                        value={formatValue(currentHpsDetails.lifesteal)}
+                                        subValue={`Weapon DPS × LifeSteal ${formatPercent(fullStats.lifeSteal)}`}
+                                        color="text-purple-400"
+                                        onInfoPointsClick={() => setShowLifestealModal(true)}
+                                    />
                                 </div>
                             </div>
 
@@ -1464,6 +1574,14 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                         value={formatValue(realHps)}
                                         subValue={`Regen: ${formatCompactNumber(currentRealHpsDetails.regen)}, LifeSteal: ${formatCompactNumber(currentRealHpsDetails.lifesteal)}, Skills: ${formatCompactNumber(currentRealHpsDetails.skills)}${currentRealHpsDetails.blockBenefit > 0 ? `, Block Benefit: +${formatCompactNumber(currentRealHpsDetails.blockBenefit)}` : ''}`}
                                         color="text-emerald-500"
+                                    />
+                                    <StatRow
+                                        icon={<Heart className="w-4 h-4" />}
+                                        label="Lifesteal/sec"
+                                        value={formatValue(currentRealHpsDetails.lifesteal)}
+                                        subValue={`Weapon DPS × LifeSteal ${formatPercent(fullStats.lifeSteal)}`}
+                                        color="text-purple-500"
+                                        onInfoPointsClick={() => setShowLifestealModal(true)}
                                     />
                                 </div>
                             </div>
@@ -1547,6 +1665,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['CriticalChance']?.count}
                                                 perf={activePerfectionDetails['CriticalChance']?.avgPerfection}
                                                 color="text-yellow-400"
+                                                {...infoProps('CriticalChance', 'Crit %', formatPercent(stats.criticalChance || 0))}
                                             />
                                             <CompactStat
                                                 icon={<TrendingUp className="w-3 h-3" />}
@@ -1556,6 +1675,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['CriticalMulti']?.count}
                                                 perf={activePerfectionDetails['CriticalMulti']?.avgPerfection}
                                                 color="text-yellow-500"
+                                                {...infoProps('CriticalMulti', 'Crit Damage', formatMultiplier(stats.criticalDamage || 0), formatMultiplier)}
                                             />
                                             <CompactStat
                                                 icon={<Shield className="w-3 h-3" />}
@@ -1564,6 +1684,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['BlockChance']?.count}
                                                 perf={activePerfectionDetails['BlockChance']?.avgPerfection}
                                                 color="text-blue-400"
+                                                {...infoProps('BlockChance', 'Block %', formatPercent(stats.blockChance || 0))}
                                             />
                                             <CompactStat
                                                 icon={<Zap className="w-3 h-3" />}
@@ -1573,6 +1694,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['DoubleDamageChance']?.count}
                                                 perf={activePerfectionDetails['DoubleDamageChance']?.avgPerfection}
                                                 color="text-purple-400"
+                                                {...infoProps('DoubleDamageChance', 'Double %', formatPercent(stats.doubleDamageChance || 0))}
                                             />
                                             <CompactStat
                                                 icon={<Heart className="w-3 h-3" />}
@@ -1581,6 +1703,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['LifeSteal']?.count}
                                                 perf={activePerfectionDetails['LifeSteal']?.avgPerfection}
                                                 color="text-purple-400"
+                                                {...infoProps('LifeSteal', 'Life Steal %', formatPercent(stats.lifeSteal || 0))}
                                             />
                                             <CompactStat
                                                 icon={<Heart className="w-3 h-3" />}
@@ -1589,6 +1712,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['HealthRegen']?.count}
                                                 perf={activePerfectionDetails['HealthRegen']?.avgPerfection}
                                                 color="text-purple-400"
+                                                {...infoProps('HealthRegen', 'Health Regen %', formatPercent(stats.healthRegen || 0))}
                                             />
                                             <CompactStat
                                                 icon={<TrendingUp className="w-3 h-3" />}
@@ -1598,6 +1722,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['AttackSpeed']?.count}
                                                 perf={activePerfectionDetails['AttackSpeed']?.avgPerfection}
                                                 color="text-orange-400"
+                                                {...infoProps('AttackSpeed', 'Attack Speed', formatMultiplier(stats.attackSpeedMultiplier), formatMultiplier)}
                                             />
                                             <CompactStat
                                                 icon={<TrendingUp className="w-3 h-3" />}
@@ -1607,6 +1732,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['SkillCooldownMulti']?.count}
                                                 perf={activePerfectionDetails['SkillCooldownMulti']?.avgPerfection}
                                                 color="text-emerald-400"
+                                                {...infoProps('SkillCooldownMulti', 'Skill CDR %', formatPercent(stats.skillCooldownReduction))}
                                             />
                                             <CompactStat
                                                 icon={<Swords className="w-3 h-3" />}
@@ -1615,6 +1741,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['DamageMulti']?.count}
                                                 perf={activePerfectionDetails['DamageMulti']?.avgPerfection}
                                                 color="text-red-400"
+                                                {...infoProps('DamageMulti', 'Damage %', formatPercent(stats.secondaryDamageMulti || 0))}
                                             />
                                             <CompactStat
                                                 icon={<Heart className="w-3 h-3" />}
@@ -1623,6 +1750,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['HealthMulti']?.count}
                                                 perf={activePerfectionDetails['HealthMulti']?.avgPerfection}
                                                 color="text-green-400"
+                                                {...infoProps('HealthMulti', 'Health %', formatPercent(stats.secondaryHealthMulti || 0))}
                                             />
                                             <CompactStat
                                                 icon={<Swords className="w-3 h-3" />}
@@ -1631,6 +1759,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['MeleeDamageMulti']?.count}
                                                 perf={activePerfectionDetails['MeleeDamageMulti']?.avgPerfection}
                                                 color="text-amber-400"
+                                                {...infoProps('MeleeDamageMulti', 'Melee DMG %', formatPercent(stats.meleeDamageMultiplier || 0))}
                                             />
                                             <CompactStat
                                                 icon={<Crosshair className="w-3 h-3" />}
@@ -1639,6 +1768,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                                 count={activePerfectionDetails['RangedDamageMulti']?.count}
                                                 perf={activePerfectionDetails['RangedDamageMulti']?.avgPerfection}
                                                 color="text-sky-400"
+                                                {...infoProps('RangedDamageMulti', 'Ranged DMG %', formatPercent(stats.rangedDamageMultiplier || 0))}
                                             />
                                         </div>
                                     );
@@ -1659,6 +1789,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                     count={activePerfectionDetails['SkillDamageMulti']?.count}
                                     perf={activePerfectionDetails['SkillDamageMulti']?.avgPerfection}
                                     color="text-red-400"
+                                    {...infoProps('SkillDamageMulti', 'Skill Damage %', formatMultiplier(stats.skillDamageMultiplier), formatMultiplier)}
                                 />
                                 <StatRow
                                     icon={<Swords className="w-3 h-3" />}
@@ -1705,6 +1836,22 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                     value={formatCompactNumber(realHps)}
                                     subValue={`Regen: ${formatCompactNumber(currentRealHpsDetails.regen)}, Life: ${formatCompactNumber(currentRealHpsDetails.lifesteal)}, Skills: ${formatCompactNumber(currentRealHpsDetails.skills)}`}
                                     color="text-emerald-500"
+                                />
+                                <StatRow
+                                    icon={<Heart className="w-4 h-4 text-purple-400" />}
+                                    label="Theo Lifesteal/sec"
+                                    value={formatCompactNumber(currentHpsDetails.lifesteal)}
+                                    subValue={`Weapon DPS × LifeSteal ${formatPercent(fullStats.lifeSteal)}`}
+                                    color="text-purple-400"
+                                    onInfoPointsClick={() => setShowLifestealModal(true)}
+                                />
+                                <StatRow
+                                    icon={<Heart className="w-4 h-4 text-purple-500" />}
+                                    label="Real Lifesteal/sec"
+                                    value={formatCompactNumber(currentRealHpsDetails.lifesteal)}
+                                    subValue={`Weapon DPS × LifeSteal ${formatPercent(fullStats.lifeSteal)}`}
+                                    color="text-purple-500"
+                                    onInfoPointsClick={() => setShowLifestealModal(true)}
                                 />
 
                                 <StatRow
@@ -1814,6 +1961,23 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                 profile={modalData?.profile || profile}
                 variant={modalData?.variant || 'default'}
                 skillLibrary={skillLibrary}
+            />
+            <LifestealBreakdownModal
+                isOpen={showLifestealModal}
+                onClose={() => { setShowLifestealModal(false); setModalData(null); }}
+                stats={modalData?.stats || fullStats}
+                profile={modalData?.profile || profile}
+                variant={modalData?.variant || 'default'}
+            />
+            <StatSourcesModal
+                isOpen={!!sourceModal}
+                onClose={() => setSourceModal(null)}
+                statKey={sourceModal?.key ?? null}
+                label={sourceModal?.label ?? ''}
+                totalDisplay={sourceModal?.total ?? ''}
+                stats={stats}
+                formatValue={sourceModal?.format ?? formatPercent}
+                multiplier={sourceModal?.multiplier}
             />
         </Card>
     );

--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -132,7 +132,9 @@ export function useGlobalStats(excludeSubstats = false): AggregatedStats | null 
         if (!itemBalancingConfig || !itemBalancingLibrary) {
             return null;
         }
-        return calculateStats(effectiveProfile, libs, excludeSubstats);
+        // Attribution is enabled here only: this hook runs per render, not in a loop.
+        // The optimizer/sweep hot paths deliberately leave it off.
+        return calculateStats(effectiveProfile, libs, excludeSubstats, { attribution: true });
     }, [effectiveProfile, libs, itemBalancingConfig, itemBalancingLibrary, excludeSubstats]);
 
     return stats;

--- a/src/hooks/useLoadoutSweep.ts
+++ b/src/hooks/useLoadoutSweep.ts
@@ -48,7 +48,7 @@ const mountKey = (m: MountSlot) => `${m.id}|${m.rarity}|${m.level}|${JSON.string
  * a full roster is tens of thousands of StatEngine runs. Results are cached, so
  * switching the ranking metric only re-sorts — it never re-sweeps.
  */
-export function useLoadoutSweep() {
+export function useLoadoutSweep(enabled: boolean = true) {
     const { profile } = useProfile();
 
     const profileRef = useRef(profile);
@@ -190,7 +190,7 @@ export function useLoadoutSweep() {
     const [results, setResults] = useState<SweepResult[]>([]);
 
     useEffect(() => {
-        if (!isReady || combos.length === 0) return;
+        if (!enabled || !isReady || combos.length === 0) return;
 
         let cancelled = false;
         let frame = 0;
@@ -235,7 +235,7 @@ export function useLoadoutSweep() {
             cancelled = true;
             cancelAnimationFrame(frame);
         };
-    }, [combos, libs, isReady, engineKey, buildTempProfile]);
+    }, [enabled, combos, libs, isReady, engineKey, buildTempProfile]);
 
     // --- Scoring ------------------------------------------------------------
     // Each metric is normalised by its own max across the sweep so that combining

--- a/src/hooks/useLoadoutSweep.ts
+++ b/src/hooks/useLoadoutSweep.ts
@@ -1,0 +1,311 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useProfile } from '../context/ProfileContext';
+import { useGameData } from './useGameData';
+import { StatEngine, LibraryData, AggregatedStats, calculateStats } from '../utils/statEngine';
+import { PetSlot, MountSlot, UserProfile } from '../types/Profile';
+import { MAX_ACTIVE_PETS } from '../utils/constants';
+
+/** How many combinations to evaluate per animation frame. */
+const BATCH_SIZE = 200;
+
+export type SweepMetric = 'lifesteal' | 'dps' | 'heal' | 'balanced';
+
+export interface LoadoutCombo {
+    petSet: PetSlot[];
+    mount: MountSlot | null;
+}
+
+/** One scored combination. Only the three ranking metrics — cheap enough for the whole sweep. */
+export interface SweepResult extends LoadoutCombo {
+    dps: number;
+    lifestealPerSec: number;
+    healPerSec: number;
+}
+
+/**
+ * A combination with its full display stats. Needs a second engine run
+ * (substats excluded) so this is computed on demand, never for the whole sweep.
+ */
+export interface ExpandedLoadout extends SweepResult {
+    /** Substats ON — "Old Stats" in the header toggle. */
+    calcStats: AggregatedStats;
+    /** Substats OFF — "New Stats" in the header toggle. */
+    shownStats: AggregatedStats;
+    shownDmg: number;
+    calcDmg: number;
+    shownHp: number;
+    calcHp: number;
+}
+
+export type SweepStatus = 'idle' | 'running' | 'done';
+
+const mountKey = (m: MountSlot) => `${m.id}|${m.rarity}|${m.level}|${JSON.stringify(m.secondaryStats)}`;
+
+/**
+ * Enumerates every pets+mount combination over the saved builds and scores each one.
+ *
+ * The sweep is time-sliced across animation frames so the page stays interactive:
+ * a full roster is tens of thousands of StatEngine runs. Results are cached, so
+ * switching the ranking metric only re-sorts — it never re-sweeps.
+ */
+export function useLoadoutSweep() {
+    const { profile } = useProfile();
+
+    const profileRef = useRef(profile);
+    profileRef.current = profile;
+
+    const { data: petLibrary } = useGameData<any>('PetLibrary.json');
+    const { data: petUpgradeLibrary } = useGameData<any>('PetUpgradeLibrary.json');
+    const { data: petBalancingLibrary } = useGameData<any>('PetBalancingLibrary.json');
+    const { data: skillLibrary } = useGameData<any>('SkillLibrary.json');
+    const { data: skillPassiveLibrary } = useGameData<any>('SkillPassiveLibrary.json');
+    const { data: mountUpgradeLibrary } = useGameData<any>('MountUpgradeLibrary.json');
+    const { data: techTreeLibrary } = useGameData<any>('TechTreeLibrary.json');
+    const { data: techTreePositionLibrary } = useGameData<any>('TechTreePositionLibrary.json');
+    const { data: guildPositionLibrary } = useGameData<any>('GuildTechTreePositionLibrary.json');
+    const { data: guildUpgradeLibrary } = useGameData<any>('GuildTechTreeUpgradeLibrary.json');
+    const { data: itemBalancingLibrary } = useGameData<any>('ItemBalancingLibrary.json');
+    const { data: itemBalancingConfig } = useGameData<any>('ItemBalancingConfig.json');
+    const { data: weaponLibrary } = useGameData<any>('WeaponLibrary.json');
+    const { data: projectilesLibrary } = useGameData<any>('ProjectilesLibrary.json');
+    const { data: secondaryStatLibrary } = useGameData<any>('SecondaryStatLibrary.json');
+    const { data: skinsLibrary } = useGameData<any>('SkinsLibrary.json');
+    const { data: setsLibrary } = useGameData<any>('SetsLibrary.json');
+    const { data: ascensionConfigsLibrary } = useGameData<any>('AscensionConfigsLibrary.json');
+
+    // Memoized so the sweep effect isn't restarted on every render.
+    const libs: LibraryData = useMemo(() => ({
+        petLibrary,
+        petUpgradeLibrary,
+        petBalancingLibrary,
+        skillLibrary,
+        skillPassiveLibrary,
+        mountUpgradeLibrary,
+        techTreeLibrary,
+        techTreePositionLibrary,
+        guildTechTreePositionLibrary: guildPositionLibrary || undefined,
+        guildTechTreeUpgradeLibrary: guildUpgradeLibrary || undefined,
+        itemBalancingLibrary,
+        itemBalancingConfig,
+        weaponLibrary,
+        projectilesLibrary,
+        secondaryStatLibrary,
+        skinsLibrary,
+        setsLibrary,
+        ascensionConfigsLibrary
+    }), [
+        petLibrary, petUpgradeLibrary, petBalancingLibrary,
+        skillLibrary, skillPassiveLibrary, mountUpgradeLibrary,
+        techTreeLibrary, techTreePositionLibrary,
+        guildPositionLibrary, guildUpgradeLibrary,
+        itemBalancingLibrary, itemBalancingConfig,
+        weaponLibrary, projectilesLibrary, secondaryStatLibrary,
+        skinsLibrary, setsLibrary, ascensionConfigsLibrary
+    ]);
+
+    const isReady = !!petLibrary && !!mountUpgradeLibrary && !!itemBalancingConfig && !!itemBalancingLibrary;
+
+    // --- Candidate pool -----------------------------------------------------
+    // Keyed on content rather than array identity: equipping a loadout picked
+    // from this very pool must not invalidate it and trigger a fresh sweep.
+    const poolKey = useMemo(() => {
+        const pets = profile.pets.savedBuilds?.length ? profile.pets.savedBuilds : profile.pets.active;
+        const mounts = [profile.mount.active, ...(profile.mount.savedBuilds || [])].filter(Boolean) as MountSlot[];
+        return JSON.stringify([pets, [...mounts.map(mountKey)].sort()]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [profile.pets.savedBuilds, profile.pets.active, profile.mount.active, profile.mount.savedBuilds]);
+
+    const combos = useMemo((): LoadoutCombo[] => {
+        const p = profileRef.current;
+
+        // Every combination of up to MAX_ACTIVE_PETS from the saved roster.
+        const savedPets = p.pets.savedBuilds || [];
+        const petSets: PetSlot[][] = [];
+        const n = savedPets.length;
+        const slotsToFill = Math.min(n, MAX_ACTIVE_PETS);
+
+        for (let i = 0; i < n; i++) {
+            const set1 = [savedPets[i]];
+            if (slotsToFill === 1) {
+                petSets.push(set1);
+                continue;
+            }
+            for (let j = i + 1; j < n; j++) {
+                const set2 = [...set1, savedPets[j]];
+                if (slotsToFill === 2) {
+                    petSets.push(set2);
+                    continue;
+                }
+                for (let k = j + 1; k < n; k++) {
+                    petSets.push([...set2, savedPets[k]]);
+                }
+            }
+        }
+        // No saved pets: keep the current active pets rather than forcing a change.
+        if (petSets.length === 0) petSets.push(p.pets.active);
+
+        // Mount candidates: current active + saved builds, deduped.
+        const mountCandidates: (MountSlot | null)[] = [];
+        const seen = new Set<string>();
+        const addMount = (m: MountSlot | null) => {
+            if (!m) return;
+            const key = mountKey(m);
+            if (seen.has(key)) return;
+            seen.add(key);
+            mountCandidates.push(m);
+        };
+        addMount(p.mount.active);
+        (p.mount.savedBuilds || []).forEach(addMount);
+        if (mountCandidates.length === 0) mountCandidates.push(p.mount.active);
+
+        const out: LoadoutCombo[] = [];
+        for (const petSet of petSets) {
+            for (const mount of mountCandidates) {
+                out.push({ petSet, mount });
+            }
+        }
+        return out;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [poolKey]);
+
+    // Everything that feeds the engine *except* the two slots the sweep overrides.
+    // Equipping a result changes only those, so it must not restart the sweep.
+    const engineKey = useMemo(() => {
+        const { pets, mount, ...rest } = profile;
+        return JSON.stringify({ ...rest, savedPets: pets.savedBuilds, savedMounts: mount.savedBuilds });
+    }, [profile]);
+
+    const buildTempProfile = useCallback((combo: LoadoutCombo): UserProfile => {
+        const p = profileRef.current;
+        return {
+            ...p,
+            pets: { ...p.pets, active: combo.petSet },
+            mount: { ...p.mount, active: combo.mount }
+        };
+    }, []);
+
+    // --- Time-sliced sweep --------------------------------------------------
+    const [status, setStatus] = useState<SweepStatus>('idle');
+    const [progress, setProgress] = useState(0);
+    const [results, setResults] = useState<SweepResult[]>([]);
+
+    useEffect(() => {
+        if (!isReady || combos.length === 0) return;
+
+        let cancelled = false;
+        let frame = 0;
+        let i = 0;
+        const acc: SweepResult[] = [];
+
+        setStatus('running');
+        setProgress(0);
+        setResults([]);
+
+        const step = () => {
+            if (cancelled) return;
+
+            const end = Math.min(i + BATCH_SIZE, combos.length);
+            for (; i < end; i++) {
+                const combo = combos[i];
+                const stats = new StatEngine(buildTempProfile(combo), libs).calculate();
+                acc.push({
+                    ...combo,
+                    // Real-time throughout: the stepped breakpoint model, matching
+                    // the Real-Time Metrics card. Lifesteal/sec and HPS below
+                    // are real-time too, so all three headline metrics agree.
+                    dps: stats.realTotalDps,
+                    lifestealPerSec: stats.realWeaponDps * stats.lifeSteal,
+                    healPerSec: stats.realTotalHps
+                });
+            }
+
+            if (i >= combos.length) {
+                setResults(acc);
+                setProgress(100);
+                setStatus('done');
+                return;
+            }
+
+            setProgress(Math.round((i / combos.length) * 100));
+            frame = requestAnimationFrame(step);
+        };
+
+        frame = requestAnimationFrame(step);
+        return () => {
+            cancelled = true;
+            cancelAnimationFrame(frame);
+        };
+    }, [combos, libs, isReady, engineKey, buildTempProfile]);
+
+    // --- Scoring ------------------------------------------------------------
+    // Each metric is normalised by its own max across the sweep so that combining
+    // DPS and HPS isn't dominated by whichever has the bigger raw scale.
+    const maxima = useMemo(() => {
+        let dps = 0, lifesteal = 0, heal = 0;
+        for (const r of results) {
+            if (r.dps > dps) dps = r.dps;
+            if (r.lifestealPerSec > lifesteal) lifesteal = r.lifestealPerSec;
+            if (r.healPerSec > heal) heal = r.healPerSec;
+        }
+        return { dps, lifesteal, heal };
+    }, [results]);
+
+    /** Normalised 0..1 score for a result under the given metric. */
+    const scoreOf = useCallback((r: SweepResult, metric: SweepMetric): number => {
+        const dpsScore = maxima.dps > 0 ? r.dps / maxima.dps : 0;
+        const lsScore = maxima.lifesteal > 0 ? r.lifestealPerSec / maxima.lifesteal : 0;
+        const healScore = maxima.heal > 0 ? r.healPerSec / maxima.heal : 0;
+
+        switch (metric) {
+            case 'dps': return dpsScore;
+            case 'lifesteal': return lsScore;
+            case 'heal': return healScore;
+            case 'balanced': return 0.5 * dpsScore + 0.5 * healScore;
+        }
+    }, [maxima]);
+
+    /** Results sorted best-first for the given metric, each with its score. */
+    const rank = useCallback((metric: SweepMetric): { result: SweepResult; score: number }[] => {
+        return results
+            .map(result => ({ result, score: scoreOf(result, metric) }))
+            .sort((a, b) => b.score - a.score);
+    }, [results, scoreOf]);
+
+    /**
+     * Adds the Shown/Calculated damage & HP columns to a combination.
+     * Costs two more engine runs, so only call it for rows actually rendered.
+     */
+    const expand = useCallback((combo: LoadoutCombo & Partial<SweepResult>): ExpandedLoadout | null => {
+        if (!isReady) return null;
+
+        const tempProfile = buildTempProfile(combo);
+        const calcStats: AggregatedStats = calculateStats(tempProfile, libs, false);
+        const shownStats: AggregatedStats = calculateStats(tempProfile, libs, true);
+
+        return {
+            petSet: combo.petSet,
+            mount: combo.mount,
+            dps: combo.dps ?? calcStats.realTotalDps,
+            lifestealPerSec: combo.lifestealPerSec ?? calcStats.realWeaponDps * calcStats.lifeSteal,
+            healPerSec: combo.healPerSec ?? calcStats.realTotalHps,
+            calcStats,
+            shownStats,
+            shownDmg: shownStats.totalDamage,
+            calcDmg: calcStats.totalDamage,
+            shownHp: shownStats.totalHealth,
+            calcHp: calcStats.totalHealth
+        };
+    }, [isReady, libs, buildTempProfile]);
+
+    return {
+        status,
+        progress,
+        results,
+        evaluatedCount: results.length,
+        totalCombos: combos.length,
+        rank,
+        scoreOf,
+        expand,
+        isReady
+    };
+}

--- a/src/hooks/useProfileOptimizer.ts
+++ b/src/hooks/useProfileOptimizer.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useProfile } from '../context/ProfileContext';
 import { useGameData } from './useGameData';
 import { StatEngine, LibraryData } from '../utils/statEngine';
-import { PetSlot, SkillSlot, UserProfile } from '../types/Profile';
+import { PetSlot, SkillSlot, MountSlot, UserProfile } from '../types/Profile';
 import { MAX_ACTIVE_PETS, MAX_ACTIVE_SKILLS } from '../utils/constants';
 
 export function useProfileOptimizer() {
@@ -13,7 +13,9 @@ export function useProfileOptimizer() {
     const { data: petUpgradeLibrary } = useGameData<any>('PetUpgradeLibrary.json');
     const { data: petBalancingLibrary } = useGameData<any>('PetBalancingLibrary.json');
     const { data: skillLibrary } = useGameData<any>('SkillLibrary.json');
-    const { data: skillPassiveLibrary } = useGameData<any>('PassiveSkillLibrary.json');
+    // Filename is SkillPassiveLibrary, not PassiveSkillLibrary — the wrong name
+    // 404s silently, dropping skill passive flat damage/health from every score.
+    const { data: skillPassiveLibrary } = useGameData<any>('SkillPassiveLibrary.json');
     const { data: mountUpgradeLibrary } = useGameData<any>('MountUpgradeLibrary.json');
     const { data: techTreeLibrary } = useGameData<any>('TechTreeLibrary.json');
     const { data: techTreePositionLibrary } = useGameData<any>('TechTreePositionLibrary.json');
@@ -49,57 +51,79 @@ export function useProfileOptimizer() {
         ascensionConfigsLibrary
     };
 
-    const optimizePets = useCallback((metric: 'dps' | 'power'): PetSlot[] | null => {
+    const optimizeLoadout = useCallback((metric: 'dps' | 'power' | 'lifesteal'): { pets: PetSlot[]; mount: MountSlot | null } | null => {
+        // --- Pet candidate sets: every combination of up to MAX_ACTIVE_PETS from saved builds ---
         const savedPets = profile.pets.savedBuilds || [];
-        if (savedPets.length === 0) return null;
-
-        let bestSet: PetSlot[] = [];
-        let bestValue = -1;
-
-        // Helper to generate combinations
+        const petSets: PetSlot[][] = [];
         const n = savedPets.length;
         const slotsToFill = Math.min(n, MAX_ACTIVE_PETS);
-
-        // Simple nested loops for small N (up to 3 slots)
-        const checkSet = (candidate: PetSlot[]) => {
-            const tempProfile: UserProfile = {
-                ...profile,
-                pets: {
-                    ...profile.pets,
-                    active: candidate
-                }
-            };
-
-            const engine = new StatEngine(tempProfile, libs);
-            const stats = engine.calculate();
-            
-            const value = metric === 'dps' ? stats.averageTotalDps : stats.power;
-            
-            if (value > bestValue) {
-                bestValue = value;
-                bestSet = candidate;
-            }
-        };
 
         for (let i = 0; i < n; i++) {
             const set1 = [savedPets[i]];
             if (slotsToFill === 1) {
-                checkSet(set1);
+                petSets.push(set1);
                 continue;
             }
             for (let j = i + 1; j < n; j++) {
                 const set2 = [...set1, savedPets[j]];
                 if (slotsToFill === 2) {
-                    checkSet(set2);
+                    petSets.push(set2);
                     continue;
                 }
                 for (let k = j + 1; k < n; k++) {
-                    checkSet([...set2, savedPets[k]]);
+                    petSets.push([...set2, savedPets[k]]);
+                }
+            }
+        }
+        // If there are no saved pets, keep the current active pets (don't force a change).
+        if (petSets.length === 0) petSets.push(profile.pets.active);
+
+        // --- Mount candidates: current active + saved builds, deduped ---
+        const mountCandidates: (MountSlot | null)[] = [];
+        const seen = new Set<string>();
+        const mountKey = (m: MountSlot) => `${m.id}|${m.rarity}|${m.level}|${JSON.stringify(m.secondaryStats)}`;
+        const addMount = (m: MountSlot | null) => {
+            if (!m) return;
+            const key = mountKey(m);
+            if (seen.has(key)) return;
+            seen.add(key);
+            mountCandidates.push(m);
+        };
+        addMount(profile.mount.active);
+        (profile.mount.savedBuilds || []).forEach(addMount);
+        // If there are no mounts at all, keep the current mount (no change).
+        if (mountCandidates.length === 0) mountCandidates.push(profile.mount.active);
+
+        const scoreOf = (stats: ReturnType<StatEngine['calculate']>): number => {
+            if (metric === 'dps') return stats.averageTotalDps;
+            if (metric === 'power') return stats.power;
+            return stats.realWeaponDps * stats.lifeSteal; // lifesteal/sec (real-time)
+        };
+
+        let bestPets: PetSlot[] = [];
+        let bestMount: MountSlot | null = profile.mount.active;
+        let bestValue = -1;
+
+        for (const petSet of petSets) {
+            for (const mount of mountCandidates) {
+                const tempProfile: UserProfile = {
+                    ...profile,
+                    pets: { ...profile.pets, active: petSet },
+                    mount: { ...profile.mount, active: mount }
+                };
+
+                const engine = new StatEngine(tempProfile, libs);
+                const value = scoreOf(engine.calculate());
+
+                if (value > bestValue) {
+                    bestValue = value;
+                    bestPets = petSet;
+                    bestMount = mount;
                 }
             }
         }
 
-        return bestSet.length > 0 ? bestSet : null;
+        return bestPets.length > 0 ? { pets: bestPets, mount: bestMount } : null;
     }, [profile, libs]);
 
     const optimizeSkills = useCallback((): SkillSlot[] | null => {
@@ -164,8 +188,8 @@ export function useProfileOptimizer() {
     }, [profile, libs, skillLibrary]);
 
     return {
-        optimizePets,
+        optimizeLoadout,
         optimizeSkills,
-        isReady: !!petLibrary && !!skillLibrary && !!itemBalancingConfig
+        isReady: !!petLibrary && !!skillLibrary && !!mountUpgradeLibrary && !!itemBalancingConfig
     };
 }

--- a/src/pages/Calculators/LoadoutOptimizer.tsx
+++ b/src/pages/Calculators/LoadoutOptimizer.tsx
@@ -1,0 +1,300 @@
+import { useCallback, useMemo, useState } from 'react';
+import { toast } from 'react-toastify';
+import { Heart, Zap, Activity, Check, Trophy, Info, PawPrint, Bike, Undo2 } from 'lucide-react';
+import { useProfile } from '../../context/ProfileContext';
+import { useGameData } from '../../hooks/useGameData';
+import { useLoadoutSweep, SweepMetric, LoadoutCombo, ExpandedLoadout } from '../../hooks/useLoadoutSweep';
+import { LoadoutComparisonModal } from '../../components/Profile/LoadoutComparisonModal';
+import { PetSlot, MountSlot } from '../../types/Profile';
+import { formatSecondaryStat } from '../../utils/statNames';
+import { formatNumber } from '../../utils/format';
+import { cn } from '../../lib/utils';
+import { Button } from '../../components/UI/Button';
+
+const METRICS: { id: SweepMetric; label: string; icon: typeof Heart; blurb: string }[] = [
+    {
+        id: 'lifesteal', label: 'Lifesteal/sec', icon: Heart,
+        blurb: 'Maximises real-time weapon DPS × lifesteal %. Ignores regen and skill healing.'
+    },
+    {
+        id: 'dps', label: 'DPS', icon: Zap,
+        blurb: 'Maximises real-time total DPS — weapon, skill and skill-buff damage on the stepped breakpoint model.'
+    },
+    {
+        id: 'heal', label: 'HPS', icon: Activity,
+        blurb: 'Maximises total real-time healing: lifesteal plus health regen and skill healing, block-amplified.'
+    },
+    {
+        id: 'balanced', label: 'Balanced', icon: Check,
+        blurb: 'Balances DPS and HPS 50/50, normalised across every combination so neither metric dominates by raw scale.'
+    }
+];
+
+/** "Lifesteal 4.92%, Crit chance 7.7%" — uses the same formatter as the item cards. */
+function describeSubstats(stats?: { statId: string; value: number }[]): string {
+    if (!stats?.length) return 'No substats';
+    return stats
+        .map(s => {
+            const { name, formattedValue } = formatSecondaryStat(s.statId, s.value);
+            return `${name} ${formattedValue.replace(/^\+/, '')}`;
+        })
+        .join(', ');
+}
+
+export default function LoadoutOptimizer() {
+    const { profile, updateNestedProfile } = useProfile();
+    const { data: petLibrary } = useGameData<any>('PetLibrary.json');
+    const { status, progress, results, evaluatedCount, totalCombos, rank, expand, isReady } = useLoadoutSweep();
+
+    const [metric, setMetric] = useState<SweepMetric>('balanced');
+    const [showComparison, setShowComparison] = useState(false);
+    const [snapshot, setSnapshot] = useState<{ pets: PetSlot[]; mount: MountSlot | null } | null>(null);
+
+    const activeMetric = METRICS.find(m => m.id === metric)!;
+
+    // "Legendary Attack" — pet type lives in the library, keyed by rarity+id.
+    const describePet = useCallback((pet: PetSlot): string => {
+        const type = petLibrary?.[`{'Rarity': '${pet.rarity}', 'Id': ${pet.id}}`]?.Type || 'Balanced';
+        return `${pet.rarity} ${type} - ${describeSubstats(pet.secondaryStats)}`;
+    }, [petLibrary]);
+
+    const describeMount = useCallback((mount: MountSlot | null): string => {
+        if (!mount) return 'No mount';
+        return `${mount.rarity} - ${describeSubstats(mount.secondaryStats)}`;
+    }, []);
+
+    const ranked = useMemo(() => (status === 'done' ? rank(metric) : []), [status, rank, metric]);
+    const top5 = useMemo(() => ranked.slice(0, 5), [ranked]);
+    const best = ranked[0]?.result ?? null;
+
+    const currentCombo: LoadoutCombo = useMemo(
+        () => ({ petSet: profile.pets.active, mount: profile.mount.active }),
+        [profile.pets.active, profile.mount.active]
+    );
+
+    const currentExpanded = useMemo(() => expand(currentCombo), [expand, currentCombo]);
+    const bestExpanded = useMemo(() => (best ? expand(best) : null), [expand, best]);
+
+    const handleEquip = () => {
+        if (!best) return;
+        setSnapshot({ pets: profile.pets.active, mount: profile.mount.active });
+        updateNestedProfile('pets', { active: best.petSet });
+        updateNestedProfile('mount', { active: best.mount });
+        toast.success('Loadout equipped');
+    };
+
+    const handleRevert = () => {
+        if (!snapshot) return;
+        updateNestedProfile('pets', { active: snapshot.pets });
+        updateNestedProfile('mount', { active: snapshot.mount });
+        setSnapshot(null);
+        toast.info('Previous loadout restored');
+    };
+
+    return (
+        <div className="space-y-6 animate-fade-in pb-20 max-w-6xl mx-auto">
+            {/* Header */}
+            <div className="space-y-1">
+                <h1 className="text-3xl md:text-4xl font-bold text-text-primary">Optimizer</h1>
+                <p className="text-text-secondary text-sm">Best pet + mount loadout over your current gear. Choose what to optimise for.</p>
+            </div>
+
+            {/* Current build */}
+            <div className="bg-bg-card/60 rounded-2xl border border-border p-4 md:p-5">
+                <div className="flex items-start justify-between gap-4">
+                    <h2 className="text-lg font-bold text-text-primary">Current build</h2>
+                    <button
+                        onClick={() => setShowComparison(true)}
+                        disabled={!currentExpanded || !bestExpanded}
+                        className="p-1.5 rounded-full text-text-muted hover:text-text-primary hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none"
+                        title="Compare current build against the proposed one"
+                    >
+                        <Info className="w-5 h-5" />
+                    </button>
+                </div>
+                <StatStrip loadout={currentExpanded} />
+                <LoadoutLines
+                    pets={profile.pets.active}
+                    mount={profile.mount.active}
+                    describePet={describePet}
+                    describeMount={describeMount}
+                />
+            </div>
+
+            {/* Metric selector */}
+            <div>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                    {METRICS.map(m => {
+                        const Icon = m.icon;
+                        const isActive = m.id === metric;
+                        return (
+                            <button
+                                key={m.id}
+                                onClick={() => setMetric(m.id)}
+                                className={cn(
+                                    "flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl border text-sm font-medium transition-all",
+                                    isActive
+                                        ? "bg-accent-primary/20 border-accent-primary/40 text-text-primary"
+                                        : "bg-transparent border-border text-text-secondary hover:bg-white/5"
+                                )}
+                            >
+                                <Icon className="w-4 h-4" />
+                                {m.label}
+                            </button>
+                        );
+                    })}
+                </div>
+                <p className="text-xs text-text-muted mt-2">{activeMetric.blurb}</p>
+            </div>
+
+            {/* Sweep progress */}
+            {(!isReady || status !== 'done') && (
+                <div className="bg-bg-card/60 rounded-2xl border border-border p-4 md:p-5 space-y-3">
+                    <div className="flex items-center justify-between text-xs text-text-secondary">
+                        <span>{isReady ? `Evaluating ${totalCombos.toLocaleString()} combinations…` : 'Loading game data…'}</span>
+                        <span className="font-mono font-bold text-accent-primary">{progress}%</span>
+                    </div>
+                    <div className="h-2 bg-bg-input rounded-full overflow-hidden">
+                        <div
+                            className="h-full bg-gradient-to-r from-accent-primary to-orange-600 transition-[width] duration-150"
+                            style={{ width: `${progress}%` }}
+                        />
+                    </div>
+                </div>
+            )}
+
+            {/* Best combination */}
+            {status === 'done' && best && (
+                <div className="bg-blue-950/30 rounded-2xl border border-blue-500/20 p-4 md:p-5">
+                    <div className="flex items-center gap-2 mb-1">
+                        <Trophy className="w-5 h-5 text-blue-400" />
+                        <h2 className="text-lg font-bold text-text-primary">Best {activeMetric.label}</h2>
+                    </div>
+                    <StatStrip loadout={bestExpanded} />
+                    <LoadoutLines
+                        pets={best.petSet}
+                        mount={best.mount}
+                        describePet={describePet}
+                        describeMount={describeMount}
+                    />
+                    <div className="flex justify-end gap-2 mt-4">
+                        {snapshot && (
+                            <Button variant="ghost" onClick={handleRevert} className="gap-2">
+                                <Undo2 className="w-4 h-4" />
+                                Revert
+                            </Button>
+                        )}
+                        <Button onClick={handleEquip} className="gap-2">
+                            <Check className="w-4 h-4" />
+                            Equip this combination
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {/* Ranked list */}
+            {status === 'done' && (
+                <div className="space-y-3">
+                    <h2 className="text-2xl font-bold text-text-primary">All combinations</h2>
+                    <p className="text-xs text-text-muted">
+                        {evaluatedCount.toLocaleString()} evaluated, ranked by {activeMetric.label}. Showing the top {top5.length}.
+                    </p>
+                    <div className="space-y-2">
+                        {top5.map(({ result, score }, idx) => (
+                            <div
+                                key={idx}
+                                className="flex items-start gap-4 p-3 bg-bg-input/20 rounded-lg border border-border/30 hover:bg-bg-input/40 transition-colors"
+                            >
+                                <span className="text-sm font-mono text-text-muted w-4 shrink-0 pt-0.5">{idx + 1}</span>
+                                <div className="min-w-0 flex-1">
+                                    <div className="text-sm text-text-primary leading-snug">
+                                        {result.petSet.map(describePet).join('  |  ')}
+                                        {'  -  '}
+                                        {describeMount(result.mount)}
+                                    </div>
+                                    <div className="text-[11px] font-mono text-text-muted mt-1">
+                                        DPS {formatNumber(result.dps)}
+                                        {'  -  '}LS/s {formatNumber(result.lifestealPerSec)}
+                                        {'  -  '}HPS {formatNumber(result.healPerSec)}
+                                    </div>
+                                </div>
+                                <span className="text-sm font-mono text-blue-400 shrink-0 pt-0.5">{Math.round(score * 100)}%</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {status === 'done' && results.length === 0 && (
+                <div className="text-center py-10 bg-bg-input/20 rounded-2xl border border-dashed border-white/10 text-text-muted text-sm italic">
+                    Nothing to optimise — save some pet and mount builds on your profile first.
+                </div>
+            )}
+
+            {currentExpanded && bestExpanded && (
+                <LoadoutComparisonModal
+                    isOpen={showComparison}
+                    onClose={() => setShowComparison(false)}
+                    current={currentExpanded}
+                    proposed={bestExpanded}
+                />
+            )}
+        </div>
+    );
+}
+
+/** The seven-column headline readout shared by the current and best cards. */
+function StatStrip({ loadout }: { loadout: ExpandedLoadout | null }) {
+    const cells: { label: string; value: number; color: string }[] = loadout ? [
+        { label: 'DPS', value: loadout.dps, color: 'text-orange-400' },
+        { label: 'Lifesteal/sec', value: loadout.lifestealPerSec, color: 'text-purple-400' },
+        { label: 'HPS', value: loadout.healPerSec, color: 'text-emerald-400' },
+        { label: 'Shown Dmg', value: loadout.shownDmg, color: 'text-red-400' },
+        { label: 'Calculated Dmg', value: loadout.calcDmg, color: 'text-red-400' },
+        { label: 'Shown HP', value: loadout.shownHp, color: 'text-green-400' },
+        { label: 'Calculated HP', value: loadout.calcHp, color: 'text-green-400' }
+    ] : [];
+
+    if (!loadout) {
+        return <div className="mt-3 h-12 rounded-lg bg-bg-input/20 animate-pulse" />;
+    }
+
+    return (
+        <div className="mt-3 flex flex-wrap gap-x-8 gap-y-3">
+            {cells.map(c => (
+                <div key={c.label} className="min-w-0">
+                    <div className="text-[10px] uppercase font-bold tracking-widest text-text-muted whitespace-nowrap">{c.label}</div>
+                    <div className={cn("text-xl md:text-2xl font-mono font-bold mt-0.5", c.color)}>{formatNumber(c.value)}</div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function LoadoutLines({
+    pets, mount, describePet, describeMount
+}: {
+    pets: PetSlot[];
+    mount: MountSlot | null;
+    describePet: (p: PetSlot) => string;
+    describeMount: (m: MountSlot | null) => string;
+}) {
+    return (
+        <div className="mt-4 pt-4 border-t border-border/40 space-y-1.5 text-sm">
+            <div className="flex gap-3">
+                <span className="flex items-center gap-1.5 text-text-muted text-xs w-16 shrink-0 pt-0.5">
+                    <PawPrint className="w-4 h-4" /> Pets
+                </span>
+                <span className="text-text-primary leading-snug">
+                    {pets.length ? pets.map(describePet).join('  |  ') : 'No pets equipped'}
+                </span>
+            </div>
+            <div className="flex gap-3">
+                <span className="flex items-center gap-1.5 text-text-muted text-xs w-16 shrink-0 pt-0.5">
+                    <Bike className="w-4 h-4" /> Mount
+                </span>
+                <span className="text-text-primary leading-snug">{describeMount(mount)}</span>
+            </div>
+        </div>
+    );
+}

--- a/src/types/statAttribution.ts
+++ b/src/types/statAttribution.ts
@@ -1,0 +1,66 @@
+/**
+ * Stat Attribution
+ * Per-source contribution records produced by StatEngine when attribution tracking is enabled.
+ *
+ * Pure types + a small pure helper: this module must stay free of engine imports so the UI
+ * can consume attribution without pulling in the calculation code.
+ */
+
+import { ItemSlot, PetSlot, MountSlot, UserProfile } from './Profile';
+
+export type SourceKind = 'item' | 'pet' | 'mount' | 'tech' | 'ascension' | 'skin' | 'set' | 'skill' | 'base';
+
+export type ItemSlotKey = keyof UserProfile['items'];
+
+/**
+ * Identifies an entity that can be rendered as a card (it has an icon).
+ * Holds a live reference into the profile - never deep-cloned.
+ */
+export type SourceRef =
+    | { kind: 'item'; slot: ItemSlotKey; item: ItemSlot }
+    | { kind: 'pet'; index: number; pet: PetSlot }
+    | { kind: 'mount'; mount: MountSlot };
+
+export interface StatContribution {
+    kind: SourceKind;
+    /** Stable React key, e.g. 'item:Weapon' | 'pet:2' | 'tech:Power:14' | 'set:Viking:4' */
+    id: string;
+    /** Display label for text-line sources, e.g. 'Power Tree - Crit Boost (L12)' */
+    label: string;
+    /** ENGINE UNITS: exactly the number the engine consumed. Never re-derived. */
+    value: number;
+    /** 'add' contributions sum; 'mul' contributions are multiplier layers rendered as xN */
+    op: 'add' | 'mul';
+    /** Present => render as a card. Absent => render as a text line. */
+    ref?: SourceRef;
+    /** Optional secondary line (e.g. 'Level 12', 'Forge Tree') */
+    detail?: string;
+}
+
+export interface StatAttribution {
+    byStat: Record<string, StatContribution[]>;
+    /** Human-readable formula per synthetic key, e.g. '__TotalDamage' */
+    formula?: Record<string, string>;
+}
+
+/** Synthetic keys for the non-additive totals (contribution view rather than sum view). */
+export const TOTAL_DAMAGE_KEY = '__TotalDamage';
+export const TOTAL_HEALTH_KEY = '__TotalHealth';
+export const TOTAL_POWER_KEY = '__TotalPower';
+
+export function isTotalKey(statKey: string): boolean {
+    return statKey.startsWith('__');
+}
+
+/**
+ * Fold stat id aliases onto the canonical PascalCase vocabulary used by statNames.ts.
+ * Applied at write time so the UI only ever looks up one key per stat.
+ */
+const STAT_KEY_ALIASES: Record<string, string> = {
+    CriticalDamage: 'CriticalMulti',
+    TimerSpeed: 'SkillCooldownMulti',
+};
+
+export function canonicalStatKey(statId: string): string {
+    return STAT_KEY_ALIASES[statId] || statId;
+}

--- a/src/utils/statEngine.ts
+++ b/src/utils/statEngine.ts
@@ -6,6 +6,10 @@
 import { UserProfile } from '../types/Profile';
 import { SKILL_MECHANICS } from './constants';
 import { getNormalizedTarget } from './ascensionUtils';
+import {
+    StatAttribution, StatContribution, SourceRef, canonicalStatKey,
+    TOTAL_DAMAGE_KEY, TOTAL_HEALTH_KEY, TOTAL_POWER_KEY
+} from '../types/statAttribution';
 
 export type StatNature = 'Multiplier' | 'Additive' | 'OneMinusMultiplier' | 'Divisor';
 
@@ -148,6 +152,13 @@ export interface AggregatedStats {
 
     // Source tracking
     statCounts: Record<string, number>;
+
+    /**
+     * Per-source contribution records. Only populated when the engine is constructed with
+     * trackAttribution=true (see calculateStats opts). Deliberately NOT part of DEFAULT_STATS:
+     * reset() deep-clones DEFAULT_STATS, which would clone the live profile refs held here.
+     */
+    attribution?: StatAttribution;
 
     // Calculation temporary properties
     equipDamageMultiplier: number;
@@ -297,6 +308,12 @@ export interface LibraryData {
     mainBattleLookup?: any;
 }
 
+/** 'CriticalChanceBoost' -> 'Critical Chance Boost' (tech node types are PascalCase ids) */
+function formatNodeType(nodeType: string): string {
+    if (!nodeType) return 'Unknown Node';
+    return nodeType.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+}
+
 export class StatEngine {
     private profile: UserProfile;
     private libs: LibraryData;
@@ -371,10 +388,15 @@ export class StatEngine {
 
     private excludeSubstats: boolean;
 
-    constructor(profile: UserProfile, libs: LibraryData, excludeSubstats = false) {
+    // Attribution tracking (opt-in: off in the optimizer/sweep hot paths)
+    private trackAttribution: boolean;
+    private attribution: StatAttribution = { byStat: {}, formula: {} };
+
+    constructor(profile: UserProfile, libs: LibraryData, excludeSubstats = false, trackAttribution = false) {
         this.profile = profile;
         this.libs = libs;
         this.excludeSubstats = excludeSubstats;
+        this.trackAttribution = trackAttribution;
         this.stats = { ...DEFAULT_STATS };
     }
 
@@ -475,6 +497,10 @@ export class StatEngine {
         this.stats = JSON.parse(JSON.stringify(DEFAULT_STATS));
         this.displayStats = {};
         this.debugLogs = [];
+
+        // Reset attribution separately: it holds live profile references and must never be
+        // routed through the DEFAULT_STATS deep clone above.
+        this.attribution = { byStat: {}, formula: {} };
 
         // Pulisci la cache ad ogni nuovo calcolo
         this.nodeValidityCache.clear();
@@ -749,6 +775,21 @@ export class StatEngine {
             this.stats.itemDamage += dmg;
             this.stats.itemHealth += hp;
 
+            // Attribution: retain the per-slot flat contribution that the accumulators above discard.
+            // Recorded PRE-melee (the weapon x1.6 is surfaced as its own layer in finalizeCalculation).
+            if (dmg !== 0) {
+                this.track(TOTAL_DAMAGE_KEY, {
+                    kind: 'item', id: `item:${slotKey}`, label: slotKey, value: dmg, op: 'add',
+                    ref: { kind: 'item', slot: slotKey as any, item }
+                });
+            }
+            if (hp !== 0) {
+                this.track(TOTAL_HEALTH_KEY, {
+                    kind: 'item', id: `item:${slotKey}`, label: slotKey, value: hp, op: 'add',
+                    ref: { kind: 'item', slot: slotKey as any, item }
+                });
+            }
+
             // Separate weapon damage (gets base melee multiplier later)
             if (slotKey === 'Weapon') {
                 this.stats.weaponDamage = dmg;
@@ -861,7 +902,8 @@ export class StatEngine {
         const petDamageBonus = this.techModifiers['PetBonusDamage'] || 0;
         const petHealthBonus = this.techModifiers['PetBonusHealth'] || 0;
 
-        for (const pet of this.profile.pets.active) {
+        for (let petIndex = 0; petIndex < this.profile.pets.active.length; petIndex++) {
+            const pet = this.profile.pets.active[petIndex];
             const upgradeData = this.libs.petUpgradeLibrary?.[pet.rarity];
             if (!upgradeData?.LevelInfo) continue;
 
@@ -911,6 +953,17 @@ export class StatEngine {
 
             this.stats.petDamage += dmg;
             this.stats.petHealth += hp;
+
+            // Attribution: dmg/hp already include tech bonus and pet ascension, so the card
+            // shows the pet's true contribution and no ascension line must be re-added on top.
+            const petRef: SourceRef = { kind: 'pet', index: petIndex, pet };
+            const petLabel = pet.customName || `${pet.rarity} Pet`;
+            if (dmg !== 0) {
+                this.track(TOTAL_DAMAGE_KEY, { kind: 'pet', id: `pet:${petIndex}`, label: petLabel, value: dmg, op: 'add', ref: petRef });
+            }
+            if (hp !== 0) {
+                this.track(TOTAL_HEALTH_KEY, { kind: 'pet', id: `pet:${petIndex}`, label: petLabel, value: hp, op: 'add', ref: petRef });
+            }
             this.debugLogs.push(`Pet ${pet.rarity} ${pet.id} (${petType}) L${pet.level} Asc${petAscensionLevel}: Damage=${dmg.toFixed(0)}, Health=${hp.toFixed(0)}`);
         }
     }
@@ -969,6 +1022,17 @@ export class StatEngine {
         this.mountHealth *= (1 + mountHpMulti) * (ascensionHpMulti || 1);
 
         this.debugLogs.push(`Mount final absolute: Damage=${this.mountDamage.toFixed(0)}, Health=${this.mountHealth.toFixed(0)}`);
+
+        // Attribution: recorded after tech + ascension are folded in, so the card shows the
+        // mount's true contribution. (mount is in scope from the early-return guard above.)
+        const mountRef: SourceRef = { kind: 'mount', mount };
+        const mountLabel = mount.customName || `${mount.rarity} Mount`;
+        if (this.mountDamage !== 0) {
+            this.track(TOTAL_DAMAGE_KEY, { kind: 'mount', id: 'mount', label: mountLabel, value: this.mountDamage, op: 'add', ref: mountRef });
+        }
+        if (this.mountHealth !== 0) {
+            this.track(TOTAL_HEALTH_KEY, { kind: 'mount', id: 'mount', label: mountLabel, value: this.mountHealth, op: 'add', ref: mountRef });
+        }
     }
 
     private incrementStatCount(statId: string) {
@@ -976,11 +1040,29 @@ export class StatEngine {
     }
 
     /**
+     * Record a per-source contribution to a stat.
+     * No-op unless attribution tracking is enabled, so hot paths pay only a boolean check.
+     *
+     * IMPORTANT: always pass the exact value the engine consumed - never a re-derived number,
+     * or the modal totals will drift from the displayed totals.
+     */
+    private track(statKey: string, c: StatContribution) {
+        if (!this.trackAttribution) return;
+        const key = canonicalStatKey(statKey);
+        (this.attribution.byStat[key] ||= []).push(c);
+    }
+
+    private trackFormula(statKey: string, formula: string) {
+        if (!this.trackAttribution) return;
+        (this.attribution.formula ||= {})[statKey] = formula;
+    }
+
+    /**
      * Collect ALL Secondary Stats from items, pets, mount (same as Verify.tsx)
      * These are stored separately and applied in finalizeCalculation
      */
     private collectAllSecondaryStats() {
-        const collectSecondary = (statId: string, rawValue: number) => {
+        const collectSecondary = (statId: string, rawValue: number, ref?: SourceRef) => {
             if (rawValue > 0) {
                 this.incrementStatCount(statId);
             }
@@ -992,6 +1074,18 @@ export class StatEngine {
             // Standardized Parsing: ALL secondary stats from items/pets are stored as Percentage Points (e.g. 10.5 = 10.5%).
             // Use strict division by 100.
             const val = rounded / 100;
+
+            // Attribution: one call covers every case below, with the exact normalized value.
+            if (ref && val !== 0) {
+                const id = ref.kind === 'item' ? `item:${ref.slot}`
+                    : ref.kind === 'pet' ? `pet:${ref.index}`
+                        : 'mount';
+                const label = ref.kind === 'item' ? ref.slot
+                    : ref.kind === 'pet' ? (ref.pet.customName || `Pet ${ref.index + 1}`)
+                        : (ref.mount.customName || 'Mount');
+                this.track(statId, { kind: ref.kind, id, label, value: val, op: 'add', ref });
+            }
+
             switch (statId) {
                 case 'DamageMulti': this.secondaryStats.damageMulti += val; break;
                 case 'HealthMulti': this.secondaryStats.healthMulti += val; break;
@@ -1034,16 +1128,17 @@ export class StatEngine {
             const item = this.profile.items[slot];
             if (item?.secondaryStats) {
                 for (const sec of item.secondaryStats) {
-                    collectSecondary(sec.statId, sec.value);
+                    collectSecondary(sec.statId, sec.value, { kind: 'item', slot, item });
                 }
             }
         }
 
         // From all pets
-        for (const pet of this.profile.pets.active) {
+        for (let petIndex = 0; petIndex < this.profile.pets.active.length; petIndex++) {
+            const pet = this.profile.pets.active[petIndex];
             if (pet.secondaryStats) {
                 for (const sec of pet.secondaryStats) {
-                    collectSecondary(sec.statId, sec.value);
+                    collectSecondary(sec.statId, sec.value, { kind: 'pet', index: petIndex, pet });
                 }
             }
         }
@@ -1055,13 +1150,14 @@ export class StatEngine {
         // (which then divides by 100), OR we just modify collectSecondary?
         // Let's modify the loop to manually add them or create a variant.
         // Easier: Just multiply by 100 here so collectSecondary's division neutralizes it.
-        if (this.profile.mount.active?.secondaryStats) {
-            for (const sec of this.profile.mount.active.secondaryStats) {
+        const activeMount = this.profile.mount.active;
+        if (activeMount?.secondaryStats) {
+            for (const sec of activeMount.secondaryStats) {
                 // REGRESSION HANDLING: Old profiles store Mount stats as fractions (e.g. 0.013).
                 // New profiles store them as percentage points (e.g. 1.3).
                 // If value < 0.5, we assume it's an old fractional value and normalize it to percentage points.
                 const val = sec.value < 0.5 ? sec.value * 100 : sec.value;
-                collectSecondary(sec.statId, val);
+                collectSecondary(sec.statId, val, { kind: 'mount', mount: activeMount });
             }
         }
 
@@ -1233,7 +1329,12 @@ export class StatEngine {
                             statNature: stat.StatNode?.UniqueStat?.StatNature as StatNature || 'Multiplier',
                             value: totalValue,
                             target: targetType,
-                            itemType: targetInfo.ItemType
+                            itemType: targetInfo.ItemType,
+                            source: {
+                                id: `tech:Clan:${nodeId}`,
+                                label: `Clan Tree - ${formatNodeType(nodeType)}`,
+                                detail: `Level ${level}`
+                            }
                         } as any);
                     }
                 }
@@ -1299,15 +1400,31 @@ export class StatEngine {
                         statNature: stat.StatNode?.UniqueStat?.StatNature as StatNature || 'Multiplier',
                         value: totalValue,
                         target: targetType,
-                        itemType: targetInfo.ItemType
+                        itemType: targetInfo.ItemType,
+                        source: {
+                            id: `tech:${tree}:${nodeId}`,
+                            label: `${tree} Tree - ${formatNodeType(node.Type)}`,
+                            detail: `Level ${level}`
+                        }
                     } as any);
                 }
             }
         }
     }
 
-    private applyStat(stat: StatEntry) {
-        const { statType, statNature, value, target } = stat;
+    private applyStat(stat: StatEntry & { source?: { id: string; label: string; detail?: string } }) {
+        const { statType, statNature, value, target, source } = stat;
+
+        // Attribution helper: record under the key the value ACTUALLY lands on, so the
+        // per-case branches below stay reconcilable against the *Breakdown fields.
+        const attribute = (statKey: string) => {
+            if (source && value !== 0) {
+                this.track(statKey, {
+                    kind: 'tech', id: source.id, label: source.label,
+                    value, op: 'add', detail: source.detail
+                });
+            }
+        };
 
         // Count sources
         let countKey = statType;
@@ -1332,13 +1449,17 @@ export class StatEngine {
                     // Tech Tree usually 'Multiplier'.
                 } else if (target === 'PlayerMeleeOnlyStatTarget') {
                     this.stats.meleeDamageMultiplier = this.combine(this.stats.meleeDamageMultiplier, value, statNature);
+                    attribute('MeleeDamageMulti');
                 } else if (target === 'PlayerRangedOnlyStatTarget') {
                     this.stats.rangedDamageMultiplier = this.combine(this.stats.rangedDamageMultiplier, value, statNature);
+                    attribute('RangedDamageMulti');
                 } else if (target === 'ActiveSkillStatTarget') {
                     // Skill Damage Multiplier
                     this.stats.skillDamageMultiplier = this.combine(this.stats.skillDamageMultiplier, value, statNature);
+                    attribute('SkillDamageMulti');
                 } else {
                     this.stats.damageMultiplier = this.combine(this.stats.damageMultiplier, value, statNature);
+                    attribute('DamageMulti');
                 }
                 break;
             case 'Health':
@@ -1346,6 +1467,7 @@ export class StatEngine {
                     this.stats.skillHealthMultiplier = this.combine(this.stats.skillHealthMultiplier, value, statNature);
                 } else if (statNature !== 'Additive') {
                     this.stats.healthMultiplier = this.combine(this.stats.healthMultiplier, value, statNature);
+                    attribute('HealthMulti');
                 }
                 break;
             case 'TimerSpeed':
@@ -1356,6 +1478,7 @@ export class StatEngine {
                     if (statNature === 'Multiplier' || statNature === 'OneMinusMultiplier') {
                         this.stats.skillCooldownBreakdown.tree += value;
                     }
+                    attribute('SkillCooldownMulti');
                 }
                 break;
             case 'CriticalChance':
@@ -1363,33 +1486,40 @@ export class StatEngine {
                 if (statNature === 'Multiplier' || statNature === 'Additive') {
                     this.stats.critChanceBreakdown.tree += value;
                 }
+                attribute('CriticalChance');
                 break;
             case 'CriticalDamage':
                 this.stats.criticalDamage = this.combine(this.stats.criticalDamage, value, statNature);
                 if (statNature === 'Multiplier' || statNature === 'Additive') {
                     this.stats.critDamageBreakdown.tree += value;
                 }
+                attribute('CriticalMulti');
                 break;
             case 'BlockChance':
                 this.stats.blockChance = this.combine(this.stats.blockChance, value, statNature);
+                attribute('BlockChance');
                 break;
             case 'DoubleDamageChance':
                 this.stats.doubleDamageChance = this.combine(this.stats.doubleDamageChance, value, statNature);
                 if (statNature === 'Multiplier' || statNature === 'Additive') {
                     this.stats.doubleDamageBreakdown.tree += value;
                 }
+                attribute('DoubleDamageChance');
                 break;
             case 'HealthRegen':
                 this.stats.healthRegen = this.combine(this.stats.healthRegen, value, statNature);
+                attribute('HealthRegen');
                 break;
             case 'LifeSteal':
                 this.stats.lifeSteal = this.combine(this.stats.lifeSteal, value, statNature);
+                attribute('LifeSteal');
                 break;
             case 'AttackSpeed':
                 this.stats.attackSpeedMultiplier = this.combine(this.stats.attackSpeedMultiplier, value, statNature);
                 if (statNature === 'Multiplier') {
                     this.stats.attackSpeedBreakdown.tree += value;
                 }
+                attribute('AttackSpeed');
                 break;
             case 'Experience':
                 this.stats.experienceMultiplier = this.combine(this.stats.experienceMultiplier, value, statNature);
@@ -1574,6 +1704,52 @@ export class StatEngine {
         this.stats.totalDamage = finalDamage;
         this.stats.totalHealth = healthAfterGlobalMultis;
 
+        // --- Attribution: base values, multiplier layers and formulas for the total views ---
+        if (this.trackAttribution) {
+            const line = (key: string, id: string, label: string, value: number, op: 'add' | 'mul', kind: any = 'base', detail?: string) => {
+                this.track(key, { kind, id, label, value, op, detail });
+            };
+
+            // Base player stats
+            line(TOTAL_DAMAGE_KEY, 'base:player', 'Base player damage', this.stats.basePlayerDamage, 'add');
+            line(TOTAL_HEALTH_KEY, 'base:player', 'Base player health', this.stats.basePlayerHealth, 'add');
+            line('CriticalMulti', 'base:critDamage', 'Base critical damage', baseStats.baseCritDamage, 'add');
+
+            // Skill passives (no card component exists for skills)
+            if (this.stats.skillPassiveDamage !== 0) {
+                line(TOTAL_DAMAGE_KEY, 'skill:passives', 'Skill passives', this.stats.skillPassiveDamage, 'add', 'skill');
+            }
+            if (this.stats.skillPassiveHealth !== 0) {
+                line(TOTAL_HEALTH_KEY, 'skill:passives', 'Skill passives', this.stats.skillPassiveHealth, 'add', 'skill');
+            }
+
+            // Weapon melee base multiplier is a damage-only layer on the weapon's flat value
+            if (isWeaponMelee) {
+                line(TOTAL_DAMAGE_KEY, 'base:melee', `Melee weapon base (weapon flat only)`, baseStats.meleeDamageMultiplier, 'mul');
+            }
+
+            // Ordered multiplier layers, in application order
+            line(TOTAL_DAMAGE_KEY, 'layer:common', 'Common multiplier (tech + damage % substats)', commonDamageMulti, 'mul', 'tech');
+            line(TOTAL_HEALTH_KEY, 'layer:common', 'Common multiplier (tech + health % substats)', commonHealthMulti, 'mul', 'tech');
+
+            if (this.forgeAscensionDamageMulti) {
+                line(TOTAL_DAMAGE_KEY, 'asc:forge', 'Forge ascension (equipment only)', this.forgeAscensionDamageMulti, 'mul', 'ascension');
+            }
+            if (this.forgeAscensionHealthMulti) {
+                line(TOTAL_HEALTH_KEY, 'asc:forge', 'Forge ascension (equipment only)', this.forgeAscensionHealthMulti, 'mul', 'ascension');
+            }
+
+            line(TOTAL_DAMAGE_KEY, 'layer:global', 'Skins + set bonuses', globalFactorDmg, 'mul', 'skin');
+            line(TOTAL_HEALTH_KEY, 'layer:global', 'Skins + set bonuses', globalFactorHp, 'mul', 'skin');
+
+            line(TOTAL_DAMAGE_KEY, 'layer:specific', isWeaponMelee ? 'Melee damage %' : 'Ranged damage %', specificDamageMulti, 'mul');
+
+            this.trackFormula(TOTAL_DAMAGE_KEY,
+                '(base + equipment x forgeAsc + pets/mount/skills) x common x (skins + sets) x melee|ranged %');
+            this.trackFormula(TOTAL_HEALTH_KEY,
+                '(base + equipment x forgeAsc + pets/mount/skills) x common x (skins + sets)');
+        }
+
         // Store the Common layer for skills/pets/mounts
         // Includes ONLY: Tech Tree Damage + Item DamageMulti substats
         // EXCLUDES: Skins and Sets (per user request)
@@ -1709,6 +1885,24 @@ export class StatEngine {
 
         const basePower = ((finalDamage - baseDmg) * powerDmgMulti + (healthAfterGlobalMultis - baseHp)) * 3;
         this.stats.power = Math.round(basePower);
+
+        // Attribution: Power is a formula over the two totals, not a sum of sources.
+        // Record the two inputs and the constants; the Damage/Health modals hold the detail.
+        if (this.trackAttribution) {
+            this.track(TOTAL_POWER_KEY, {
+                kind: 'base', id: 'power:damage', label: 'Total damage (above base)', op: 'add',
+                value: finalDamage - baseDmg, detail: `x${powerDmgMulti} - see Total Damage for its sources`
+            });
+            this.track(TOTAL_POWER_KEY, {
+                kind: 'base', id: 'power:health', label: 'Total health (above base)', op: 'add',
+                value: healthAfterGlobalMultis - baseHp, detail: 'see Total Health for its sources'
+            });
+            this.track(TOTAL_POWER_KEY, {
+                kind: 'base', id: 'power:scale', label: 'Power scaling constant', value: 3, op: 'mul'
+            });
+            this.trackFormula(TOTAL_POWER_KEY,
+                `((Damage - ${baseDmg}) x ${powerDmgMulti} + (Health - ${baseHp})) x 3`);
+        }
 
 
 
@@ -1870,11 +2064,40 @@ export class StatEngine {
 
         this.debugLogs.push(`FINAL DPS: Weapon=${this.stats.weaponDps.toFixed(0)}, RealWeapon=${this.stats.realWeaponDps.toFixed(0)}, Total=${this.stats.averageTotalDps.toFixed(0)}`);
         this.debugLogs.push(`FINAL HPS: Theo=${this.stats.theoreticalTotalHps.toFixed(0)}, Real=${this.stats.realTotalHps.toFixed(0)}`);
+
+        this.publishAttribution();
     } // end finalizeCalculation
+
+    /**
+     * Attach attribution to the result. Assigned by reference (never cloned) so the SourceRef
+     * entries keep pointing at live profile objects.
+     */
+    private publishAttribution() {
+        if (!this.trackAttribution) return;
+
+        // excludeSubstats zeroes item/pet/mount contributions for these four keys only
+        // (see the itemDmgMulti/itemMeleeDmgMulti guards above). Drop the matching entries
+        // so the modal never lists a card that contributed nothing in this mode.
+        if (this.excludeSubstats) {
+            const substatExcludedKeys = ['DamageMulti', 'HealthMulti', 'MeleeDamageMulti', 'RangedDamageMulti'];
+            for (const key of substatExcludedKeys) {
+                const entries = this.attribution.byStat[key];
+                if (!entries) continue;
+                this.attribution.byStat[key] = entries.filter(e => !e.ref);
+            }
+        }
+
+        this.stats.attribution = this.attribution;
+    }
 } // end class
 
-export function calculateStats(profile: UserProfile, libs: LibraryData, excludeSubstats = false): any {
-    const engine = new StatEngine(profile, libs, excludeSubstats);
+export function calculateStats(
+    profile: UserProfile,
+    libs: LibraryData,
+    excludeSubstats = false,
+    opts?: { attribution?: boolean }
+): any {
+    const engine = new StatEngine(profile, libs, excludeSubstats, opts?.attribution === true);
     if (typeof window !== 'undefined') {
         (window as any).debugCalculator = engine;
     }


### PR DESCRIPTION
## Summary

Three related additions to the profile/calculator tooling.

### Loadout Optimizer
- New screen that sweeps equipment/pet/mount loadouts and ranks them by DPS, HPS, lifesteal/sec, or a balanced score.
- Uses real-time DPS and supports joint pets + mount optimization.
- Current vs proposed comparison modal to preview a swap before equipping.

### Lifesteal per second
- New metric surfaced across the stats panel, with its own breakdown modal and an auto-apply button.

### Character stats source breakdown
- A clickable info icon on 16 stat cards (Total Power/Damage/Health and the percentage passives) opens a modal listing every source contributing to that total.
- Items, pets and mounts render as cards; tech tree, ascension, skins, sets and base values render as text lines.
- The total stats mirror the card's own multiplier breakdown (Items/Tree/Asc/Skins/Sets), so the modal numbers match the card by construction.
- Follows the New/Old Stats (substats) toggle.
- Backed by opt-in attribution tracking inside the stat engine. It is purely additive and left off in the optimizer sweep paths, so no computed stat value changes.

## Testing
- `tsc --noEmit` clean and production `vite build` passes.