### PR TITLE
Loadout optimizer and stat-breakdown improvements

### DIFF
--- a/src/components/Profile/EquipmentPanel.tsx
+++ b/src/components/Profile/EquipmentPanel.tsx
@@ -595,7 +595,16 @@ function MountSlotWidget({ variant, isCompact }: { variant: string; isCompact: b
     const mountData = mount ? getMountStats() : null;
     const mountStats = mountData ? { damage: mountData.damage, health: mountData.health } : null;
     const currentAscension = mountData?.ascLevel || 0;
-    const isDifferent = variant === 'test' && testMount?.id !== originalMount?.id;
+    // Full-content diff (matches the pet cards), so an auto-optimized swap to a
+    // different level/stat variant of the same mount id also flags as changed.
+    const isDifferent = variant === 'test' && (() => {
+        const cur = testMount;
+        const orig = originalMount;
+        if (!cur && !orig) return false;
+        if (!cur || !orig) return true;
+        return cur.id !== orig.id || cur.rarity !== orig.rarity || cur.level !== orig.level ||
+            JSON.stringify(cur.secondaryStats) !== JSON.stringify(orig.secondaryStats);
+    })();
 
     const perfection = useMemo(() => {
         if (!mount || !secondaryStatLibrary) return null;

--- a/src/components/Profile/MiscPanel.tsx
+++ b/src/components/Profile/MiscPanel.tsx
@@ -1,14 +1,16 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useProfile } from '../../context/ProfileContext';
 import { useGameData } from '../../hooks/useGameData';
 import { useForgeUpgradeStats } from '../../hooks/useForgeCalculator';
 import { Card } from '../UI/Card';
 import { Button } from '../UI/Button';
 import { SpriteIcon } from '../UI/SpriteIcon';
-import { Plus, Minus } from 'lucide-react';
+import { Plus, Minus, Sparkles } from 'lucide-react';
 import { AscensionStars } from '../UI/AscensionStars';
 import { getAnvilTexturePath } from '../../utils/ascensionUtils';
 import { useGameDataContext } from '../../context/GameDataContext';
+import { getAveragePerfection } from '../../utils/itemCalculations';
+import { PerfectionMeter } from '../UI/PerfectionMeter';
 
 export function MiscPanel() {
     const { profile, updateNestedProfile } = useProfile();
@@ -16,7 +18,14 @@ export function MiscPanel() {
     const { data: forgeData } = useGameData<any>('ForgeUpgradeLibrary.json');
     const { data: forgeConfig } = useGameData<any>('ForgeConfig.json');
     const { data: ascData } = useGameData<any>('AscensionConfigsLibrary.json');
+    const { data: secondaryStatLibrary } = useGameData<any>('SecondaryStatLibrary.json');
     const { selectedVersion } = useGameDataContext();
+
+    // Average perfection across all equipped gear: the 8 items + active pets + mount.
+    const avgPerfection = useMemo(() => getAveragePerfection(
+        [...Object.values(profile.items), ...profile.pets.active, profile.mount.active],
+        secondaryStatLibrary
+    ), [profile.items, profile.pets.active, profile.mount.active, secondaryStatLibrary]);
     // Determine max forge level from config
     // If there are 34 upgrade entries, it means we can reach Level 35
     const maxForgeLevel = forgeData ? Math.max(...Object.keys(forgeData).map(Number)) + 1 : 99;
@@ -203,37 +212,56 @@ export function MiscPanel() {
                     )}
                 </Card>
 
-                {/* Egg Slots */}
-                <Card className="p-4 bg-bg-secondary/40 border-border/50">
-                    <div className="flex items-center gap-3 mb-4">
-                        <div className="w-10 h-10 rounded-lg bg-bg-input flex items-center justify-center p-1">
-                            <img src={`${import.meta.env.BASE_URL}Texture2D/${selectedVersion}/HatchBed.png`} alt="Egg Slots" className="w-full h-full object-contain" />
+                {/* Egg Slots + Average Perfection (share one grid column, each half width) */}
+                <div className="grid grid-cols-2 gap-4 content-start">
+                    {/* Egg Slots */}
+                    <Card className="p-4 bg-bg-secondary/40 border-border/50">
+                        <div className="flex items-center gap-3 mb-4">
+                            <div className="w-10 h-10 rounded-lg bg-bg-input flex items-center justify-center p-1 shrink-0">
+                                <img src={`${import.meta.env.BASE_URL}Texture2D/${selectedVersion}/HatchBed.png`} alt="Egg Slots" className="w-full h-full object-contain" />
+                            </div>
+                            <div className="min-w-0">
+                                <div className="font-bold">Egg Slots</div>
+                                <div className="text-xs text-text-muted">Max hatching ({minEggSlots}-{maxEggSlots})</div>
+                            </div>
                         </div>
-                        <div>
-                            <div className="font-bold">Egg Slots</div>
-                            <div className="text-xs text-text-muted">Max hatching capacity ({minEggSlots}-{maxEggSlots})</div>
+                        <div className="flex items-center justify-between bg-bg-input p-2 rounded-lg border border-border">
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => updateMisc('eggSlots', Math.max(minEggSlots, profile.misc.eggSlots - 1))}
+                                disabled={profile.misc.eggSlots <= minEggSlots}
+                            >
+                                <Minus className="w-4 h-4" />
+                            </Button>
+                            <span className="font-mono font-bold text-lg">{profile.misc.eggSlots}</span>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => updateMisc('eggSlots', Math.min(maxEggSlots, profile.misc.eggSlots + 1))}
+                                disabled={profile.misc.eggSlots >= maxEggSlots}
+                            >
+                                <Plus className="w-4 h-4" />
+                            </Button>
                         </div>
-                    </div>
-                    <div className="flex items-center justify-between bg-bg-input p-2 rounded-lg border border-border">
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => updateMisc('eggSlots', Math.max(minEggSlots, profile.misc.eggSlots - 1))}
-                            disabled={profile.misc.eggSlots <= minEggSlots}
-                        >
-                            <Minus className="w-4 h-4" />
-                        </Button>
-                        <span className="font-mono font-bold text-lg">{profile.misc.eggSlots}</span>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => updateMisc('eggSlots', Math.min(maxEggSlots, profile.misc.eggSlots + 1))}
-                            disabled={profile.misc.eggSlots >= maxEggSlots}
-                        >
-                            <Plus className="w-4 h-4" />
-                        </Button>
-                    </div>
-                </Card>
+                    </Card>
+
+                    {/* Average Perfection */}
+                    <Card className="p-4 bg-bg-secondary/40 border-border/50">
+                        <div className="flex items-center gap-3 mb-4">
+                            <div className="w-10 h-10 rounded-lg bg-bg-input flex items-center justify-center p-1 shrink-0">
+                                <Sparkles className="w-5 h-5 text-accent-primary" />
+                            </div>
+                            <div className="min-w-0">
+                                <div className="font-bold">Avg Perfection</div>
+                                <div className="text-xs text-text-muted">Across all equipped gear</div>
+                            </div>
+                        </div>
+                        <div className="flex items-center bg-bg-input p-2.5 rounded-lg border border-border">
+                            <PerfectionMeter value={avgPerfection} className="w-full gap-3" barClassName="h-2.5" />
+                        </div>
+                    </Card>
+                </div>
             </div>
         </div>
     );

--- a/src/components/Profile/MountSelectorModal.tsx
+++ b/src/components/Profile/MountSelectorModal.tsx
@@ -637,6 +637,10 @@ export function MountSelectorModal({ isOpen, onClose, onSelect, currentMount, co
                                                     Object.entries(mountsConfig.mapping).find(([_, v]: [any, any]) => v.id === savedMount.id && v.rarity === savedMount.rarity)
                                                     : null;
                                                 const isSelected = selectedSavedIndex === originalIdx;
+                                                const activeMount = profile.mount.active;
+                                                const isEquipped = !!activeMount &&
+                                                    activeMount.id === savedMount.id && activeMount.rarity === savedMount.rarity &&
+                                                    JSON.stringify(activeMount.secondaryStats) === JSON.stringify(savedMount.secondaryStats);
 
                                                 return (
                                                     <ItemSelectionCard
@@ -647,6 +651,7 @@ export function MountSelectorModal({ isOpen, onClose, onSelect, currentMount, co
                                                         itemName={savedMount.customName || (spriteInfo ? (spriteInfo[1] as any).name : `Mount #${savedMount.id}`)}
                                                         itemImage={null}
                                                         isSelected={isSelected}
+                                                        isEquipped={isEquipped}
                                                         rarity={savedMount.rarity}
                                                         hideAgeStyles={true}
                                                         perfection={getPerfection(savedMount)}

--- a/src/components/Profile/PetPanel.tsx
+++ b/src/components/Profile/PetPanel.tsx
@@ -2,7 +2,7 @@ import { useProfile } from '../../context/ProfileContext';
 import { useComparison } from '../../context/ComparisonContext';
 import { useGameDataContext } from '../../context/GameDataContext';
 import { Card } from '../UI/Card';
-import { Zap as PowerIcon, Plus, Cat, Sword, RotateCcw, Heart } from 'lucide-react';
+import { Zap as PowerIcon, Plus, Cat, Sword, RotateCcw, Heart, Scale } from 'lucide-react';
 import { Button } from '../UI/Button';
 import { PetSlot, MountSlot } from '../../types/Profile';
 import { useState, useMemo } from 'react';
@@ -215,16 +215,17 @@ export function PetPanel({ variant = 'default', title, comparePets }: PetPanelPr
     // Optimizer searches saved pets AND saved mounts, so enable when either pool has entries.
     const autoDisabled = (profile.pets.savedBuilds?.length || 0) < 1 && (profile.mount.savedBuilds?.length || 0) < 1;
 
-    const handleAutoOptimize = (metric: 'dps' | 'power' | 'lifesteal') => {
+    // Only rendered for the default (non-compare) panel. Compare mode drives its
+    // own optimizer from the comparison strip (see StatsSummaryPanel).
+    const handleAutoOptimize = (metric: 'dps' | 'power' | 'lifesteal' | 'balanced') => {
         setPreviousPets([...activePets]);
-        if (variant === 'default') setPreviousMount(profile.mount.active);
+        setPreviousMount(profile.mount.active);
 
         const best = optimizeLoadout(metric);
         if (!best) return;
 
         updatePets(best.pets);
-        // Mount is a single global slot with no per-variant override, so only apply in default.
-        if (variant === 'default') updateNestedProfile('mount', { active: best.mount });
+        updateNestedProfile('mount', { active: best.mount });
     };
 
     const handleRevert = () => {
@@ -341,6 +342,7 @@ export function PetPanel({ variant = 'default', title, comparePets }: PetPanelPr
                         {panelTitle}
                     </h2>
                     
+                    {variant === 'default' && (
                     <div className="flex items-center gap-1.5 flex-wrap">
                         <Button
                             variant="outline"
@@ -375,6 +377,17 @@ export function PetPanel({ variant = 'default', title, comparePets }: PetPanelPr
                             <Heart className="w-3 h-3" />
                             AUTO LIFESTEAL/SEC
                         </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 px-2 text-[10px] font-bold border-violet-500/20 hover:bg-violet-500/10 hover:border-violet-500/40 text-violet-400 gap-1 active:scale-95 transition-all w-fit"
+                            onClick={() => handleAutoOptimize('balanced')}
+                            disabled={!isReady || autoDisabled}
+                            title="Select best 3 pets + mount for a balance of DPS and HPS (same scoring as the Loadout Optimizer)"
+                        >
+                            <Scale className="w-3 h-3" />
+                            AUTO BALANCED
+                        </Button>
                         {(previousPets || previousMount !== undefined) && (
                             <Button 
                                 variant="ghost" 
@@ -387,6 +400,7 @@ export function PetPanel({ variant = 'default', title, comparePets }: PetPanelPr
                             </Button>
                         )}
                     </div>
+                    )}
                 </div>
 
                 <div className="flex items-center justify-end">

--- a/src/components/Profile/PetSelectorModal.tsx
+++ b/src/components/Profile/PetSelectorModal.tsx
@@ -708,6 +708,10 @@ export function PetSelectorModal({ isOpen, onClose, onSelect, currentPet, contex
 
                                             const spriteIndex = spriteInfo ? parseInt(spriteInfo[0]) : 0;
                                             const isSelected = selectedSavedIndex === originalIdx;
+                                            const isEquipped = profile.pets.active.some(ap =>
+                                                ap.id === savedPet.id && ap.rarity === savedPet.rarity &&
+                                                JSON.stringify(ap.secondaryStats) === JSON.stringify(savedPet.secondaryStats)
+                                            );
 
                                             return (
                                                 <ItemSelectionCard
@@ -720,6 +724,7 @@ export function PetSelectorModal({ isOpen, onClose, onSelect, currentPet, contex
                                                     rarity={savedPet.rarity}
                                                     isSaved={true}
                                                     isSelected={isSelected}
+                                                    isEquipped={isEquipped}
                                                     hideAgeStyles={true}
                                                     perfection={getPerfection(savedPet)}
                                                     getStatPerfection={getStatPerfection}

--- a/src/components/Profile/StatSourcesModal.tsx
+++ b/src/components/Profile/StatSourcesModal.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { X, Cat, Info } from 'lucide-react';
+import { X, Cat, Info, Bike } from 'lucide-react';
 import { Button } from '../UI/Button';
 import { ItemSelectionCard } from '../UI/ItemSelectionCard';
 import { SpriteSheetIcon } from '../UI/SpriteSheetIcon';
@@ -145,13 +145,19 @@ const ModalContent = memo(({ statKey, label, totalDisplay, stats, formatValue, m
         }
 
         const mount = ref.mount;
+        const mountsConfig = spriteMapping?.mounts;
+        const mountSpriteEntry = mountsConfig?.mapping
+            ? Object.entries(mountsConfig.mapping).find(
+                ([, v]: [string, any]) => v.id === mount.id && v.rarity === mount.rarity)
+            : undefined;
+        const mountSpriteIndex = mountSpriteEntry ? parseInt(mountSpriteEntry[0]) : null;
         return (
             <ItemSelectionCard
                 key={c.id}
                 item={mount}
                 slotKey="mount"
                 slotLabel="Mount"
-                itemName={mount.customName || `${mount.rarity} Mount`}
+                itemName={mount.customName || (mountSpriteEntry ? (mountSpriteEntry[1] as any).name : `${mount.rarity} Mount`)}
                 itemImage={null}
                 rarity={mount.rarity}
                 hideAgeStyles
@@ -159,6 +165,19 @@ const ModalContent = memo(({ statKey, label, totalDisplay, stats, formatValue, m
                 currentLevel={mount.level}
                 spriteMapping={spriteMapping}
                 customStats={contribution}
+                renderIcon={() => mountSpriteIndex !== null && mountsConfig ? (
+                    <SpriteSheetIcon
+                        textureSrc={getAscensionTexturePath('MountIcons', (mount as any).ascensionLevel || 0, selectedVersion)}
+                        spriteWidth={mountsConfig.sprite_size.width}
+                        spriteHeight={mountsConfig.sprite_size.height}
+                        sheetWidth={mountsConfig.texture_size.width}
+                        sheetHeight={mountsConfig.texture_size.height}
+                        iconIndex={mountSpriteIndex}
+                        className="w-10 h-10"
+                    />
+                ) : (
+                    <Bike className={cn('w-8 h-8 opacity-50', `text-rarity-${mount.rarity.toLowerCase()}`)} />
+                )}
             />
         );
     };

--- a/src/components/Profile/StatsSummaryPanel.tsx
+++ b/src/components/Profile/StatsSummaryPanel.tsx
@@ -4,7 +4,7 @@ import {
     Swords, Heart, Shield, Zap, Target, Gauge,
     TrendingUp, Clock, Coins, Star, Crosshair, TreeDeciduous, Sparkles,
     ArrowUp, ArrowDown, X, Check, ArrowRight, Hash, Minimize2, Layout, Download,
-    ArrowLeftRight, Info, Scale
+    ArrowLeftRight, Info, Sword, Scale, RotateCcw, Layers
 } from 'lucide-react';
 import { Button } from '../UI/Button';
 import { AnimatedClock } from '../UI/AnimatedClock';
@@ -15,12 +15,14 @@ import { useGlobalStats } from '../../hooks/useGlobalStats';
 import { useTreeModifiers } from '../../hooks/useCalculatedStats';
 import { getStatName } from '../../utils/statNames';
 import { useComparison } from '../../context/ComparisonContext';
-import { useLoadoutSweep } from '../../hooks/useLoadoutSweep';
 import { useProfile } from '../../context/ProfileContext';
 import { useGameData } from '../../hooks/useGameData';
 import { calculateStats, LibraryData, AggregatedStats } from '../../utils/statEngine';
 import { useTreeMode } from '../../context/TreeModeContext';
-import { UserProfile } from '../../types/Profile';
+import { UserProfile, PetSlot, MountSlot } from '../../types/Profile';
+import { useProfileOptimizer } from '../../hooks/useProfileOptimizer';
+import { getAveragePerfection } from '../../utils/itemCalculations';
+import { PerfectionMeter } from '../UI/PerfectionMeter';
 import { DpsBreakdownModal } from './DpsBreakdownModal';
 import { LifestealBreakdownModal } from './LifestealBreakdownModal';
 import { StatSourcesModal, MultiplierBreakdown } from './StatSourcesModal';
@@ -435,25 +437,69 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
         testSkills,
         originalUseSkinWindup,
         testUseSkinWindup,
+        updateTestPet,
+        updateTestMount,
         exitCompareMode,
         keepOriginal,
         applyTestBuild,
         loadProfileIntoTest,
-        updateTestPet,
-        updateTestMount,
         isCompactStats,
         setIsCompactStats,
         excludeSubstats,
         setExcludeSubstats
     } = useComparison();
-    // Same balanced principle as the Loadout Optimizer: sweep the saved pet+mount
-    // builds and rank by 0.5·DPS + 0.5·HPS (each normalised across the sweep).
-    // Only runs while comparing so it adds no background cost to the normal panel.
-    const { status: sweepStatus, rank: rankLoadout } = useLoadoutSweep(isComparing);
     const stats = useGlobalStats(excludeSubstats);
     const fullStats = useGlobalStats(false);
     const techModifiers = useTreeModifiers() as Record<string, number>;
     const { profile, profiles, activeProfileId } = useProfile();
+
+    // --- Auto-optimize the Test build (drives the strip's AUTO buttons) --------
+    const { optimizeLoadout, isReady: optimizerReady } = useProfileOptimizer();
+    // undefined = nothing to revert; null = revert to "no mount equipped"
+    const [previousTestPets, setPreviousTestPets] = useState<PetSlot[] | null>(null);
+    const [previousTestMount, setPreviousTestMount] = useState<MountSlot | null | undefined>(undefined);
+    // On: score saved builds at their own level. Off: score everything at level 1.
+    const [respectSavedLevels, setRespectSavedLevels] = useState(true);
+
+    // Saved builds are global, so the optimizer has candidates whenever either pool is non-empty.
+    const autoOptimizeDisabled = !optimizerReady
+        || ((profile.pets.savedBuilds?.length || 0) < 1 && (profile.mount.savedBuilds?.length || 0) < 1);
+
+    const handleAutoOptimizeTest = (metric: 'dps' | 'power' | 'lifesteal' | 'balanced') => {
+        // Evaluate against the Test build's own items/mount/ascensions, keeping
+        // everything the Test side doesn't override (tech tree, passives, saved builds).
+        const testBase: UserProfile = {
+            ...profile,
+            items: testItems ?? profile.items,
+            mount: { ...profile.mount, active: testMount ?? profile.mount.active },
+            pets: { ...profile.pets, active: testPets ?? profile.pets.active },
+            skills: { ...profile.skills, equipped: testSkills ?? profile.skills.equipped },
+            misc: {
+                ...profile.misc,
+                forgeAscensionLevel: testForgeAscension ?? profile.misc.forgeAscensionLevel,
+                mountAscensionLevel: testMountAscension ?? profile.misc.mountAscensionLevel,
+                petAscensionLevel: testPetAscension ?? profile.misc.petAscensionLevel,
+                skillAscensionLevel: testSkillAscension ?? profile.misc.skillAscensionLevel,
+                useSkinWindup: testUseSkinWindup ?? profile.misc.useSkinWindup,
+            },
+        };
+
+        setPreviousTestPets(testPets ? [...testPets] : null);
+        setPreviousTestMount(testMount);
+
+        const best = optimizeLoadout(metric, testBase, respectSavedLevels);
+        if (!best) return;
+
+        updateTestPet(best.pets);
+        updateTestMount(best.mount);
+    };
+
+    const handleRevertTest = () => {
+        if (previousTestPets) updateTestPet(previousTestPets);
+        if (previousTestMount !== undefined) updateTestMount(previousTestMount);
+        setPreviousTestPets(null);
+        setPreviousTestMount(undefined);
+    };
 
     const { treeMode, setTreeMode } = useTreeMode();
 
@@ -474,6 +520,16 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
     const { data: skinsLibrary } = useGameData<any>('SkinsLibrary.json');
     const { data: setsLibrary } = useGameData<any>('SetsLibrary.json');
     const { data: ascensionConfigsLibrary } = useGameData<any>('AscensionConfigsLibrary.json');
+
+    // Average perfection across all gear (items + pets + mount) for each compare side.
+    const originalPerfection = useMemo(() => originalItems ? getAveragePerfection(
+        [...Object.values(originalItems), ...(originalPets || []), originalMount],
+        secondaryStatLibrary
+    ) : null, [originalItems, originalPets, originalMount, secondaryStatLibrary]);
+    const testPerfection = useMemo(() => testItems ? getAveragePerfection(
+        [...Object.values(testItems), ...(testPets || []), testMount],
+        secondaryStatLibrary
+    ) : null, [testItems, testPets, testMount, secondaryStatLibrary]);
 
     const treeModeLabels: Record<typeof treeMode, string> = {
         empty: 'Empty Tree',
@@ -711,16 +767,6 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
     const formatValue = (val: number) => isCompactStats
         ? formatCompactNumber(val)
         : val.toLocaleString(undefined, { maximumFractionDigits: 0 });
-
-    // "Auto Balanced": load the balanced-best pet+mount loadout (from the saved
-    // builds) into the test side, using the Loadout Optimizer's scoring verbatim.
-    const autoBalancedReady = sweepStatus === 'done';
-    const applyAutoBalanced = () => {
-        const best = rankLoadout('balanced')[0]?.result;
-        if (!best) return;
-        updateTestPet(best.petSet);
-        updateTestMount(best.mount);
-    };
 
     // The comparison UI block
     // The comparison UI block
@@ -1217,17 +1263,6 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                             </select>
                         </div>
                     )}
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={applyAutoBalanced}
-                        disabled={!autoBalancedReady}
-                        title="Fill the test build with the balanced-best pet + mount loadout from your saved builds (same scoring as the Loadout Optimizer)"
-                        className="h-8 sm:h-10 px-2 flex flex-col items-center justify-center p-0 gap-0.5 text-[9px] text-violet-400/70 hover:text-violet-400 hover:bg-violet-500/10 border border-transparent hover:border-violet-500/20 transition-all font-bold uppercase tracking-tight disabled:opacity-40 disabled:cursor-not-allowed"
-                    >
-                        <Scale className={cn("w-3.5 h-3.5", !autoBalancedReady && "animate-pulse")} />
-                        <span>Auto Bal</span>
-                    </Button>
                     <Button variant="ghost" size="sm" onClick={exitCompareMode} className="h-8 sm:h-10 px-2 sm:px-6 gap-1 sm:gap-2 text-[10px] sm:text-xs text-text-muted hover:text-red-400 hover:bg-red-500/10 border border-transparent hover:border-red-500/20 transition-all font-bold">
                         <X className="w-3.5 h-3.5 sm:w-4 h-4" />
                         <span className="hidden sm:inline">Exit Comparison</span>
@@ -1243,6 +1278,97 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                         <span className="hidden sm:inline">Apply Test Build</span>
                         <span className="inline sm:hidden tracking-tight">Apply Test</span>
                     </Button>
+                </div>
+                )}
+
+                {isComparing && !actualHideActions && (
+                <div className="flex items-center justify-between gap-2 flex-wrap w-full pt-2">
+                    {/* Equipped build perfection (far left) */}
+                    <div className="flex flex-col gap-1 px-2.5 py-1.5 rounded-lg border border-border bg-bg-input/30 min-w-[120px] shrink-0">
+                        <span className="text-[9px] font-bold uppercase tracking-widest text-text-muted/70 text-center">Equipped Perfection</span>
+                        <PerfectionMeter value={originalPerfection} className="gap-2" />
+                    </div>
+
+                    {/* Auto Test Build controls (center) */}
+                    <div className="flex items-center justify-center gap-1.5 flex-wrap">
+                    <span className="text-[9px] font-bold uppercase tracking-widest text-text-muted/60 mr-0.5">Auto Test Build</span>
+                    <button
+                        onClick={() => setRespectSavedLevels(v => !v)}
+                        role="switch"
+                        aria-checked={respectSavedLevels}
+                        title="On: score saved builds at their own level. Off: score everything at level 1, so only secondary stats decide. Equipping always keeps the saved level."
+                        className={cn(
+                            "h-7 px-2 text-[10px] font-bold rounded border gap-1 inline-flex items-center active:scale-95 transition-all w-fit",
+                            respectSavedLevels
+                                ? "border-accent-primary/40 bg-accent-primary/10 text-accent-primary"
+                                : "border-border bg-bg-input/30 text-text-muted hover:text-text-primary"
+                        )}
+                    >
+                        <Layers className="w-3 h-3" />
+                        {respectSavedLevels ? 'SAVED LVL' : 'LVL 1'}
+                    </button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-2 text-[10px] font-bold border-red-500/20 hover:bg-red-500/10 hover:border-red-500/40 text-red-400 gap-1 active:scale-95 transition-all w-fit"
+                        onClick={() => handleAutoOptimizeTest('dps')}
+                        disabled={autoOptimizeDisabled}
+                        title="Set best 3 pets + mount for Max DPS on the Test build"
+                    >
+                        <Sword className="w-3 h-3" />
+                        AUTO DPS
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-2 text-[10px] font-bold border-amber-500/20 hover:bg-amber-500/10 hover:border-amber-500/40 text-amber-500 gap-1 active:scale-95 transition-all w-fit"
+                        onClick={() => handleAutoOptimizeTest('power')}
+                        disabled={autoOptimizeDisabled}
+                        title="Set best 3 pets + mount for Max Power on the Test build"
+                    >
+                        <Zap className="w-3 h-3" />
+                        AUTO POWER
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-2 text-[10px] font-bold border-purple-500/20 hover:bg-purple-500/10 hover:border-purple-500/40 text-purple-400 gap-1 active:scale-95 transition-all w-fit"
+                        onClick={() => handleAutoOptimizeTest('lifesteal')}
+                        disabled={autoOptimizeDisabled}
+                        title="Set best 3 pets + mount for Max Lifesteal/sec on the Test build"
+                    >
+                        <Heart className="w-3 h-3" />
+                        AUTO LIFESTEAL/SEC
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-2 text-[10px] font-bold border-violet-500/20 hover:bg-violet-500/10 hover:border-violet-500/40 text-violet-400 gap-1 active:scale-95 transition-all w-fit"
+                        onClick={() => handleAutoOptimizeTest('balanced')}
+                        disabled={autoOptimizeDisabled}
+                        title="Set best 3 pets + mount for a balance of DPS and HPS on the Test build (same scoring as the Loadout Optimizer)"
+                    >
+                        <Scale className="w-3 h-3" />
+                        AUTO BALANCED
+                    </Button>
+                    {(previousTestPets || previousTestMount !== undefined) && (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-[10px] font-bold text-text-muted hover:text-white gap-1 active:scale-95 transition-all w-fit"
+                            onClick={handleRevertTest}
+                        >
+                            <RotateCcw className="w-3 h-3" />
+                            REVERT
+                        </Button>
+                    )}
+                    </div>
+
+                    {/* Test build perfection (far right) */}
+                    <div className="flex flex-col gap-1 px-2.5 py-1.5 rounded-lg border border-accent-primary/30 bg-accent-primary/5 min-w-[120px] shrink-0">
+                        <span className="text-[9px] font-bold uppercase tracking-widest text-accent-primary/80 text-center">Test Perfection</span>
+                        <PerfectionMeter value={testPerfection} className="gap-2" />
+                    </div>
                 </div>
                 )}
 
@@ -1385,7 +1511,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                     <div className="mt-4 pt-4 border-t border-border/30 space-y-4">
                         <div className="space-y-3">
                             <div className="text-[10px] text-text-muted text-center font-bold uppercase tracking-widest opacity-60">Build Actions</div>
-                            <div className="grid grid-cols-2 gap-2">
+                            <div className="grid grid-cols-4 gap-2">
                                 {/* Load Profile - Small Button with hidden select */}
                                 {profiles.length > 1 && (
                                     <div className="relative">
@@ -1418,17 +1544,6 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                 <Button
                                     variant="ghost"
                                     size="sm"
-                                    onClick={applyAutoBalanced}
-                                    disabled={!autoBalancedReady}
-                                    title="Fill the test build with the balanced-best pet + mount loadout from your saved builds (same scoring as the Loadout Optimizer)"
-                                    className="h-10 flex flex-col items-center justify-center p-0 gap-1 text-[10px] text-violet-400/70 hover:text-violet-400 grayscale hover:grayscale-0 transition-all font-bold uppercase tracking-tight border border-transparent hover:border-violet-500/20 bg-violet-500/5 disabled:opacity-40 disabled:cursor-not-allowed"
-                                >
-                                    <Scale className={cn("w-4 h-4", !autoBalancedReady && "animate-pulse")} />
-                                    <span>Auto Balanced</span>
-                                </Button>
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
                                     onClick={exitCompareMode}
                                     className="h-10 flex flex-col items-center justify-center p-0 gap-1 text-[10px] text-text-muted hover:text-red-400 grayscale hover:grayscale-0 transition-all font-bold uppercase tracking-tight border border-transparent hover:border-red-500/20"
                                 >
@@ -1448,7 +1563,7 @@ export function StatsSummaryPanel({ variant = 'sidebar', onClose, hideActions = 
                                     variant="primary"
                                     size="sm"
                                     onClick={applyTestBuild}
-                                    className="col-span-2 h-10 flex flex-col items-center justify-center p-0 gap-1 text-[10px] font-bold uppercase tracking-tight bg-accent-primary shadow-lg shadow-accent-primary/10 hover:scale-105 transition-transform"
+                                    className="h-10 flex flex-col items-center justify-center p-0 gap-1 text-[10px] font-bold uppercase tracking-tight bg-accent-primary shadow-lg shadow-accent-primary/10 hover:scale-105 transition-transform"
                                 >
                                     <ArrowRight className="w-4 h-4" />
                                     <span>Apply Test</span>

--- a/src/components/UI/ItemSelectionCard.tsx
+++ b/src/components/UI/ItemSelectionCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X, Bookmark, Shield, Minus, Plus } from 'lucide-react';
+import { X, Bookmark, Shield, Minus, Plus, Check } from 'lucide-react';
 import { ItemSlot, MountSlot, PetSlot } from '../../types/Profile';
 import { AscensionStars } from './AscensionStars';
 import { cn, getAgeBgStyle, getAgeBorderStyle, getRarityBgStyle, getRarityBorderStyle } from '../../lib/utils';
@@ -15,6 +15,8 @@ interface ItemSelectionCardProps {
     slotLabel: string;
     isSelected?: boolean;
     hasDiff?: boolean;
+    /** Marks a saved build that is currently equipped on the active profile. */
+    isEquipped?: boolean;
     globalAscensionLevel?: number;
     isSaved?: boolean;
     itemName: string;
@@ -75,6 +77,7 @@ export function ItemSelectionCard({
     slotLabel,
     isSelected,
     hasDiff,
+    isEquipped,
     globalAscensionLevel = 0,
     isSaved,
     itemName,
@@ -110,7 +113,9 @@ export function ItemSelectionCard({
                 isCompact ? "min-h-[130px]" : "min-h-[160px]",
                 isSelected
                     ? "border-accent-primary bg-accent-primary/10 shadow-lg shadow-accent-primary/20"
-                    : "border-border hover:border-accent-primary/50",
+                    : isEquipped
+                        ? "border-green-500/60 hover:border-green-400"
+                        : "border-border hover:border-accent-primary/50",
                 hasDiff && "ring-2 ring-yellow-500 ring-offset-2 ring-offset-bg-primary"
             )}
             style={
@@ -119,6 +124,14 @@ export function ItemSelectionCard({
                     : { background: getAgeBgStyle((item as ItemSlot)?.age || 0).background?.toString().replace('0.5', isSelected ? '0.3' : '0.15').replace('0.2', isSelected ? '0.15' : '0.08') }
             }
         >
+            {/* Equipped badge */}
+            {isEquipped && (
+                <div className="absolute top-1 left-1/2 -translate-x-1/2 z-30 flex items-center gap-0.5 bg-green-500 text-white text-[8px] font-black uppercase tracking-wider px-1.5 py-0.5 rounded-full shadow-sm border border-green-300/50">
+                    <Check className="w-2.5 h-2.5" strokeWidth={3} />
+                    Equipped
+                </div>
+            )}
+
             {/* Top Row Overlay: Level/Ascension (Left) and Actions (Right) */}
             <div className="w-full px-2 z-20 flex flex-wrap justify-between items-start gap-1 mb-1">
                 <div className="flex flex-col gap-1 min-w-0">

--- a/src/components/UI/PerfectionMeter.tsx
+++ b/src/components/UI/PerfectionMeter.tsx
@@ -1,0 +1,37 @@
+import { cn } from '../../lib/utils';
+
+/** Colored perfection bar with the % to its right — matches the item/pet cards. */
+export function PerfectionMeter({
+    value,
+    className,
+    barClassName
+}: {
+    /** 0–100, or null when nothing has secondary stats yet. */
+    value: number | null;
+    className?: string;
+    barClassName?: string;
+}) {
+    const v = value ?? 0;
+    const has = value !== null;
+
+    const textColor = !has ? 'text-text-muted'
+        : v >= 100 ? 'text-yellow-400'
+        : v >= 80 ? 'text-green-500'
+        : v >= 50 ? 'text-blue-500'
+        : 'text-gray-400';
+    const barColor = v >= 100 ? 'bg-yellow-400'
+        : v >= 80 ? 'bg-green-500'
+        : v >= 50 ? 'bg-blue-500'
+        : 'bg-gray-500';
+
+    return (
+        <div className={cn('flex items-center gap-2', className)}>
+            <div className={cn('flex-1 min-w-0 bg-gray-700 rounded-full overflow-hidden', barClassName ?? 'h-2')}>
+                <div className={cn('h-full', barColor)} style={{ width: `${Math.min(100, v)}%` }} />
+            </div>
+            <span className={cn('font-mono font-bold shrink-0', textColor)}>
+                {has ? `${v.toFixed(1)}%` : '—'}
+            </span>
+        </div>
+    );
+}

--- a/src/hooks/useLoadoutSweep.ts
+++ b/src/hooks/useLoadoutSweep.ts
@@ -48,7 +48,12 @@ const mountKey = (m: MountSlot) => `${m.id}|${m.rarity}|${m.level}|${JSON.string
  * a full roster is tens of thousands of StatEngine runs. Results are cached, so
  * switching the ranking metric only re-sorts — it never re-sweeps.
  */
-export function useLoadoutSweep(enabled: boolean = true) {
+/**
+ * @param respectSavedLevels When true (default) each saved build is scored at its own
+ * stored level. When false, every candidate is scored at level 1 so only secondary
+ * stats decide — equipping still uses the saved level.
+ */
+export function useLoadoutSweep(respectSavedLevels: boolean = true) {
     const { profile } = useProfile();
 
     const profileRef = useRef(profile);
@@ -177,12 +182,19 @@ export function useLoadoutSweep(enabled: boolean = true) {
 
     const buildTempProfile = useCallback((combo: LoadoutCombo): UserProfile => {
         const p = profileRef.current;
+        // Off mode: score every candidate at level 1 so only secondary stats decide.
+        const petSet = respectSavedLevels
+            ? combo.petSet
+            : combo.petSet.map(pet => ({ ...pet, level: 1 }));
+        const mount = (respectSavedLevels || !combo.mount)
+            ? combo.mount
+            : { ...combo.mount, level: 1 };
         return {
             ...p,
-            pets: { ...p.pets, active: combo.petSet },
-            mount: { ...p.mount, active: combo.mount }
+            pets: { ...p.pets, active: petSet },
+            mount: { ...p.mount, active: mount }
         };
-    }, []);
+    }, [respectSavedLevels]);
 
     // --- Time-sliced sweep --------------------------------------------------
     const [status, setStatus] = useState<SweepStatus>('idle');
@@ -190,7 +202,7 @@ export function useLoadoutSweep(enabled: boolean = true) {
     const [results, setResults] = useState<SweepResult[]>([]);
 
     useEffect(() => {
-        if (!enabled || !isReady || combos.length === 0) return;
+        if (!isReady || combos.length === 0) return;
 
         let cancelled = false;
         let frame = 0;
@@ -235,7 +247,7 @@ export function useLoadoutSweep(enabled: boolean = true) {
             cancelled = true;
             cancelAnimationFrame(frame);
         };
-    }, [enabled, combos, libs, isReady, engineKey, buildTempProfile]);
+    }, [combos, libs, isReady, engineKey, buildTempProfile]);
 
     // --- Scoring ------------------------------------------------------------
     // Each metric is normalised by its own max across the sweep so that combining
@@ -250,7 +262,7 @@ export function useLoadoutSweep(enabled: boolean = true) {
         return { dps, lifesteal, heal };
     }, [results]);
 
-    /** Normalised 0..1 score for a result under the given metric. */
+    /** 0..1 score for a result under the given metric (relative to the sweep's best). */
     const scoreOf = useCallback((r: SweepResult, metric: SweepMetric): number => {
         const dpsScore = maxima.dps > 0 ? r.dps / maxima.dps : 0;
         const lsScore = maxima.lifesteal > 0 ? r.lifestealPerSec / maxima.lifesteal : 0;
@@ -260,7 +272,13 @@ export function useLoadoutSweep(enabled: boolean = true) {
             case 'dps': return dpsScore;
             case 'lifesteal': return lsScore;
             case 'heal': return healScore;
-            case 'balanced': return 0.5 * dpsScore + 0.5 * healScore;
+            // Geometric mean of DPS and HPS, not a 0.5/0.5 average: the product rewards
+            // being strong on BOTH axes and collapses if either is weak, which is what a
+            // balanced build is. sqrt(dps/max · heal/max) ranks identically to the raw
+            // product dps·heal (the extra constants and sqrt are monotonic), and stays in
+            // 0..1 only so the "% of best" column can render it. Matches the Substats
+            // Calculator's dps·hps and useProfileOptimizer's balanced metric.
+            case 'balanced': return Math.sqrt(dpsScore * healScore);
         }
     }, [maxima]);
 

--- a/src/hooks/useProfileOptimizer.ts
+++ b/src/hooks/useProfileOptimizer.ts
@@ -51,9 +51,13 @@ export function useProfileOptimizer() {
         ascensionConfigsLibrary
     };
 
-    const optimizeLoadout = useCallback((metric: 'dps' | 'power' | 'lifesteal'): { pets: PetSlot[]; mount: MountSlot | null } | null => {
+    // respectSavedLevels: when true (default), each saved build is scored at its own
+    // stored level — the original behavior. When false, every candidate is scored at
+    // level 1 so only secondary stats decide. Either way the returned build keeps its
+    // saved level for equipping.
+    const optimizeLoadout = useCallback((metric: 'dps' | 'power' | 'lifesteal' | 'balanced', base: UserProfile = profile, respectSavedLevels: boolean = true): { pets: PetSlot[]; mount: MountSlot | null } | null => {
         // --- Pet candidate sets: every combination of up to MAX_ACTIVE_PETS from saved builds ---
-        const savedPets = profile.pets.savedBuilds || [];
+        const savedPets = base.pets.savedBuilds || [];
         const petSets: PetSlot[][] = [];
         const n = savedPets.length;
         const slotsToFill = Math.min(n, MAX_ACTIVE_PETS);
@@ -76,7 +80,7 @@ export function useProfileOptimizer() {
             }
         }
         // If there are no saved pets, keep the current active pets (don't force a change).
-        if (petSets.length === 0) petSets.push(profile.pets.active);
+        if (petSets.length === 0) petSets.push(base.pets.active);
 
         // --- Mount candidates: current active + saved builds, deduped ---
         const mountCandidates: (MountSlot | null)[] = [];
@@ -89,37 +93,62 @@ export function useProfileOptimizer() {
             seen.add(key);
             mountCandidates.push(m);
         };
-        addMount(profile.mount.active);
-        (profile.mount.savedBuilds || []).forEach(addMount);
+        addMount(base.mount.active);
+        (base.mount.savedBuilds || []).forEach(addMount);
         // If there are no mounts at all, keep the current mount (no change).
-        if (mountCandidates.length === 0) mountCandidates.push(profile.mount.active);
+        if (mountCandidates.length === 0) mountCandidates.push(base.mount.active);
+
+        // Evaluate every combination once. "Balanced" needs two passes (it
+        // normalises DPS and HPS by their maxima across the sweep), so keep the
+        // full stats around rather than collapsing to a single scalar up front.
+        type Combo = { pets: PetSlot[]; mount: MountSlot | null; stats: ReturnType<StatEngine['calculate']> };
+        const combos: Combo[] = [];
+        for (const petSet of petSets) {
+            for (const mount of mountCandidates) {
+                // Score at level 1 when respectSavedLevels is off; the original
+                // petSet/mount (with saved levels) are still what we push and return.
+                const scoredPets = respectSavedLevels
+                    ? petSet
+                    : petSet.map(p => ({ ...p, level: 1 }));
+                const scoredMount = (respectSavedLevels || !mount)
+                    ? mount
+                    : { ...mount, level: 1 };
+                const tempProfile: UserProfile = {
+                    ...base,
+                    pets: { ...base.pets, active: scoredPets },
+                    mount: { ...base.mount, active: scoredMount }
+                };
+                const engine = new StatEngine(tempProfile, libs);
+                combos.push({ pets: petSet, mount, stats: engine.calculate() });
+            }
+        }
+        if (combos.length === 0) return null;
 
         const scoreOf = (stats: ReturnType<StatEngine['calculate']>): number => {
-            if (metric === 'dps') return stats.averageTotalDps;
+            // Real-time DPS, matching the Loadout Optimizer sweep (not the theoretical average).
+            if (metric === 'dps') return stats.realTotalDps;
             if (metric === 'power') return stats.power;
+            if (metric === 'balanced') {
+                // Geometric mean (product) of real-time DPS and HPS. Unlike a weighted
+                // sum of the two, the product rewards being strong on BOTH axes and
+                // collapses toward zero if either is weak — that's what a balanced build
+                // actually is. Raw scale is fine: the product is scale-invariant for
+                // ranking, so no normalisation is needed. Matches the Substats Calculator.
+                return stats.realTotalDps * stats.realTotalHps;
+            }
             return stats.realWeaponDps * stats.lifeSteal; // lifesteal/sec (real-time)
         };
 
         let bestPets: PetSlot[] = [];
-        let bestMount: MountSlot | null = profile.mount.active;
+        let bestMount: MountSlot | null = base.mount.active;
         let bestValue = -1;
 
-        for (const petSet of petSets) {
-            for (const mount of mountCandidates) {
-                const tempProfile: UserProfile = {
-                    ...profile,
-                    pets: { ...profile.pets, active: petSet },
-                    mount: { ...profile.mount, active: mount }
-                };
-
-                const engine = new StatEngine(tempProfile, libs);
-                const value = scoreOf(engine.calculate());
-
-                if (value > bestValue) {
-                    bestValue = value;
-                    bestPets = petSet;
-                    bestMount = mount;
-                }
+        for (const c of combos) {
+            const value = scoreOf(c.stats);
+            if (value > bestValue) {
+                bestValue = value;
+                bestPets = c.pets;
+                bestMount = c.mount;
             }
         }
 

--- a/src/pages/Calculators/LoadoutOptimizer.tsx
+++ b/src/pages/Calculators/LoadoutOptimizer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
-import { Heart, Zap, Activity, Check, Trophy, Info, PawPrint, Bike, Undo2 } from 'lucide-react';
+import { Heart, Zap, Activity, Check, Trophy, Info, PawPrint, Bike, Undo2, Layers } from 'lucide-react';
 import { useProfile } from '../../context/ProfileContext';
 import { useGameData } from '../../hooks/useGameData';
 import { useLoadoutSweep, SweepMetric, LoadoutCombo, ExpandedLoadout } from '../../hooks/useLoadoutSweep';
@@ -44,7 +44,8 @@ function describeSubstats(stats?: { statId: string; value: number }[]): string {
 export default function LoadoutOptimizer() {
     const { profile, updateNestedProfile } = useProfile();
     const { data: petLibrary } = useGameData<any>('PetLibrary.json');
-    const { status, progress, results, evaluatedCount, totalCombos, rank, expand, isReady } = useLoadoutSweep();
+    const [respectSavedLevels, setRespectSavedLevels] = useState(true);
+    const { status, progress, results, evaluatedCount, totalCombos, rank, expand, isReady } = useLoadoutSweep(respectSavedLevels);
 
     const [metric, setMetric] = useState<SweepMetric>('balanced');
     const [showComparison, setShowComparison] = useState(false);
@@ -145,6 +146,30 @@ export default function LoadoutOptimizer() {
                     })}
                 </div>
                 <p className="text-xs text-text-muted mt-2">{activeMetric.blurb}</p>
+
+                {/* Level basis toggle */}
+                <div className="mt-3 flex items-center gap-3 flex-wrap">
+                    <button
+                        onClick={() => setRespectSavedLevels(v => !v)}
+                        role="switch"
+                        aria-checked={respectSavedLevels}
+                        title="On: score each saved build at its own level. Off: score every candidate at level 1 so only secondary stats decide. Equipping always keeps the saved level."
+                        className={cn(
+                            "inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border text-xs font-medium transition-all",
+                            respectSavedLevels
+                                ? "bg-accent-primary/20 border-accent-primary/40 text-text-primary"
+                                : "bg-transparent border-border text-text-secondary hover:bg-white/5"
+                        )}
+                    >
+                        <Layers className="w-4 h-4" />
+                        Level basis: {respectSavedLevels ? 'Saved' : 'Level 1'}
+                    </button>
+                    <span className="text-xs text-text-muted">
+                        {respectSavedLevels
+                            ? "Using each saved build's own level."
+                            : 'Ignoring saved levels — comparing everything at level 1.'}
+                    </span>
+                </div>
             </div>
 
             {/* Sweep progress */}

--- a/src/utils/itemCalculations.ts
+++ b/src/utils/itemCalculations.ts
@@ -81,6 +81,28 @@ export const getPerfection = (item: ItemSlot, secondaryStatLibrary: any): number
 };
 
 /**
+ * Average perfection across a set of gear (items, pets, mount) — anything carrying
+ * secondaryStats. Entries without secondary stats (or nulls) are skipped, so the
+ * result is the mean of each piece's own perfection. Returns null if nothing qualifies.
+ */
+export const getAveragePerfection = (
+    entries: ({ secondaryStats?: { statId: string; value: number }[] } | null | undefined)[],
+    secondaryStatLibrary: any
+): number | null => {
+    let total = 0;
+    let count = 0;
+    for (const entry of entries) {
+        if (!entry) continue;
+        const p = getPerfection(entry as ItemSlot, secondaryStatLibrary);
+        if (p !== null) {
+            total += p;
+            count++;
+        }
+    }
+    return count > 0 ? total / count : null;
+};
+
+/**
  * Calculates perfection for a single stat
  */
 export const getStatPerfection = (statIdx: string, value: number, secondaryStatLibrary: any): number | null => {


### PR DESCRIPTION
This PR bundles the work built on top of the merged Loadout Optimizer (#8) into a single squashed commit. All changes are additive on the profile/comparison screens and the calculators — no changes to build config or CI (the fork's `deploy.yml` changes are intentionally left out).

## Loadout optimization

- **Geometric-mean balanced scoring.** The Loadout Optimizer sweep and Auto Balanced now score balance as a geometric mean instead of `0.5·(dps/max) + 0.5·(hps/max)`, so a build must be strong on **both** axes — a lopsided 100/20 no longer ties an even 60/60.
- **Auto DPS scores on real-time DPS** (`realTotalDps`) to match the Loadout Optimizer sweep; balanced/lifesteal already used real-time metrics.
- **Level-basis toggle** on both optimizers: on (default, original behavior) scores each saved build at its own level; off scores every candidate at flat level 1 so only secondary stats decide. Equipping always keeps the saved level — the override affects scoring only.
- **Auto optimize moved into the compare strip**, targeting the Test build and applying both the best pets and the best mount. `optimizeLoadout` takes an optional base profile so the search evaluates against the Test build's own items/ascensions.

## UI & display

- **Average-perfection meters.** New "Avg Perfection" card in the Misc panel showing mean perfection across all equipped gear (items + pets + mount), plus Equipped/Test perfection boxes flanking the Auto Test Build controls in comparison mode. Backed by a shared `PerfectionMeter` component and `getAveragePerfection` helper.
- **Mount sprite in the stat-source breakdown modal** (previously rendered an empty box; now looks up the sprite from `ManualSpriteMapping` like the mount panel).
- **Mount "changed" flag on full content diff** — the Test-build mount card now compares id/rarity/level/secondaryStats like the pet cards, so an auto-optimized swap to a different variant of the same mount gets the yellow border.
- **"Equipped" badge** on saved pet/mount build cards that match the currently equipped item (by id/rarity/secondary stats), via a new `isEquipped` prop on `ItemSelectionCard`.

## Files

13 files changed, +457 / −118. New file: `src/components/UI/PerfectionMeter.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
