### PR TITLE
fix(pvp): default disabled double damage to zero

### DIFF
--- a/src/utils/PvpBattleEngine.ts
+++ b/src/utils/PvpBattleEngine.ts
@@ -674,7 +674,7 @@ export function enemyConfigToPvpStats(
     let critMulti = passives.CriticalMulti?.enabled ? 1 + (passives.CriticalMulti.value / 100) : 1.5;
     let blockChance = passives.BlockChance?.enabled ? passives.BlockChance.value / 100 : 0;
     let lifesteal = passives.LifeSteal?.enabled ? passives.LifeSteal.value / 100 : 0;
-    let doubleDamage = passives.DoubleDamageChance?.enabled ? passives.DoubleDamageChance.value / 100 : 1.0;
+    let doubleDamage = passives.DoubleDamageChance?.enabled ? passives.DoubleDamageChance.value / 100 : 0;
     let healthRegen = passives.HealthRegen?.enabled ? passives.HealthRegen.value / 100 : 0;
     let damageMulti = passives.DamageMulti?.enabled ? passives.DamageMulti.value / 100 : 0;
     let healthMulti = passives.HealthMulti?.enabled ? passives.HealthMulti.value / 100 : 0;


### PR DESCRIPTION
## Summary

- Treat an absent or disabled Double Damage Chance passive as 0%.
- Preserve percentage conversion for enabled values.

## Root cause

`enemyConfigToPvpStats()` used `1.0` as the disabled fallback. The combat engine interprets that value as a 100% proc chance, so every normal opponent attack performed a second strike.

## Impact

Newly configured PVP opponents no longer receive guaranteed double attacks by default. Explicit enabled values continue to behave as configured.

## Validation

- Runtime conversion probe:
  - absent passive → `0`
  - disabled passive → `0`
  - enabled at 25% → `0.25`

Closes #10
