### PR TITLE
fix(pvp): target opponent in randomized order

### DIFF
--- a/src/utils/PvpBattleEngine.ts
+++ b/src/utils/PvpBattleEngine.ts
@@ -373,7 +373,7 @@ export class PvpBattleEngine {
             this.processMovementAndCombat(this.player2, this.player1, dt, startOfTickDistance, !p2Status.isDead);
         } else {
             this.processMovementAndCombat(this.player2, this.player1, dt, startOfTickDistance, !p2Status.isDead);
-            this.processMovementAndCombat(this.player1, this.player1, dt, startOfTickDistance, !p1Status.isDead);
+            this.processMovementAndCombat(this.player1, this.player2, dt, startOfTickDistance, !p1Status.isDead);
         }
     }
 


### PR DESCRIPTION
## Summary

- Target Player 2 when processing Player 1 in the second randomized combat-order branch.
- Keep the randomized execution order unchanged.

## Root cause

The final `processMovementAndCombat()` call passed Player 1 as both attacker and target. Once in range, a melee Player 1 could resolve its attack against itself.

## Impact

Player 1 no longer self-damages based on combat processing order, removing an asymmetric bias from PVP simulation results.

## Validation

- Deterministic runtime probe forcing the second order branch:
  - Player 1 wins with full health.
  - Player 2 reaches 0 health.

Closes #11
