### PR TITLE
fix(pvp): correct health conversion and cooldowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "dev": "npm run update-configs && vite",
         "build": "npm run update-contributors && npm run update-configs && tsc -b && vite build",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+        "test:pvp": "node --import tsx --test src/utils/PvpBattleEngine.test.ts",
         "preview": "vite preview"
     },
     "dependencies": {

--- a/src/components/Pvp/EnemyBuilder.tsx
+++ b/src/components/Pvp/EnemyBuilder.tsx
@@ -309,7 +309,10 @@ export function EnemyBuilder() {
     };
 
     const runSimulation = async () => {
-        if (!globalStats || !skillLibrary || !weaponLibrary || !pvpBaseConfig || !mountUpgradeLibrary) return;
+        if (
+            !globalStats || !skillLibrary || !weaponLibrary || !pvpBaseConfig
+            || !mountUpgradeLibrary || !petUpgradeLibrary || !petLibrary || !petBalancingLibrary
+        ) return;
 
         setIsSimulating(true);
         setSimResults(null);
@@ -324,13 +327,7 @@ export function EnemyBuilder() {
                     skillLibrary,
                     weaponLibrary,
                     profile.items.Weapon,
-                    pvpBaseConfig,
-                    {
-                        pets: profile.misc?.petAscensionLevel || 0,
-                        skills: profile.misc?.skillAscensionLevel || 0,
-                        mounts: profile.misc?.mountAscensionLevel || 0
-                    },
-                    ascensionConfigsLibrary
+                    pvpBaseConfig
                 );
 
                 // 2. Convert Player 2 (Enemy) Stats
@@ -339,6 +336,7 @@ export function EnemyBuilder() {
                     weaponLibrary,
                     pvpBaseConfig,
                     mountUpgradeLibrary,
+                    petUpgradeLibrary,
                     petLibrary,
                     petBalancingLibrary,
                     ascensionConfigsLibrary
@@ -369,7 +367,10 @@ export function EnemyBuilder() {
 
     // Helper to get current stats for visualizer
     const getBattleStats = (): { p1: PvpPlayerStats, p2: PvpPlayerStats } | null => {
-        if (!globalStats || !skillLibrary || !weaponLibrary || !pvpBaseConfig || !mountUpgradeLibrary) return null;
+        if (
+            !globalStats || !skillLibrary || !weaponLibrary || !pvpBaseConfig
+            || !mountUpgradeLibrary || !petUpgradeLibrary || !petLibrary || !petBalancingLibrary
+        ) return null;
         try {
             const p1 = aggregatedStatsToPvpStats(
                 globalStats,
@@ -377,21 +378,17 @@ export function EnemyBuilder() {
                 skillLibrary,
                 weaponLibrary,
                 profile.items.Weapon,
-                pvpBaseConfig,
-                {
-                    pets: profile.misc?.petAscensionLevel || 0,
-                    skills: profile.misc?.skillAscensionLevel || 0,
-                    mounts: profile.misc?.mountAscensionLevel || 0
-                },
-                ascensionConfigsLibrary
+                pvpBaseConfig
             );
             const p2 = enemyConfigToPvpStats(
                 enemy,
                 weaponLibrary,
                 pvpBaseConfig,
                 mountUpgradeLibrary,
+                petUpgradeLibrary,
                 petLibrary,
-                petBalancingLibrary
+                petBalancingLibrary,
+                ascensionConfigsLibrary
             );
             return { p1, p2 };
         } catch (e) {

--- a/src/utils/PvpBattleEngine.test.ts
+++ b/src/utils/PvpBattleEngine.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { INITIAL_PROFILE, type UserProfile } from '../types/Profile';
+import type { AggregatedStats } from './statEngine';
+import {
+    PvpBattleEngine,
+    aggregatedStatsToPvpStats,
+    enemyConfigToPvpStats,
+    profileToEnemyConfig,
+    type PvpPlayerStats,
+} from './PvpBattleEngine';
+
+const pvpConfig = {
+    PvpHpBaseMultiplier: 1,
+    PvpHpPetMultiplier: 0.5,
+    PvpHpSkillMultiplier: 0.25,
+    PvpHpMountMultiplier: 2,
+};
+
+const playerStats = (cooldownReduction: number): PvpPlayerStats => ({
+    hp: 100,
+    damage: 10,
+    attackSpeed: 1,
+    critChance: 0,
+    critMulti: 1.5,
+    blockChance: 0,
+    lifesteal: 0,
+    doubleDamage: 0,
+    healthRegen: 0,
+    damageMulti: 0,
+    healthMulti: 0,
+    skillDamageMulti: 1,
+    skillCooldownMulti: cooldownReduction,
+    skills: [{
+        id: 'TestSkill',
+        cooldown: 10,
+        duration: 0,
+        hasDamage: true,
+        hasHealth: false,
+        damage: 10,
+        count: 1,
+        damageIsPerHit: false,
+    }],
+});
+
+const enemyConfig = (hp: number, pets: any[] = []) => ({
+    name: 'Enemy',
+    weapon: null,
+    skills: [],
+    stats: { hp, damage: 10 },
+    passiveStats: {},
+    pets,
+    mount: null,
+});
+
+test('builds missing pet health from PetUpgradeLibrary', () => {
+    const pet = { rarity: 'Rare', id: 7, level: 1, evolution: 0 };
+    const petUpgradeLibrary = {
+        Rare: {
+            LevelInfo: [{
+                Level: 0,
+                PetStats: {
+                    Stats: [{
+                        Value: 100,
+                        StatNode: { UniqueStat: { StatType: 'Health' } },
+                    }],
+                },
+            }],
+        },
+    };
+    const petLibrary = {
+        "{'Rarity': 'Rare', 'Id': 7}": { Type: 'Tank' },
+    };
+    const petBalancingLibrary = {
+        Tank: { DamageMultiplier: 1, HealthMultiplier: 2 },
+    };
+
+    const stats = enemyConfigToPvpStats(
+        enemyConfig(1200, [pet]),
+        undefined,
+        { ...pvpConfig, PvpHpSkillMultiplier: 0.5, PvpHpMountMultiplier: 2 },
+        undefined,
+        petUpgradeLibrary,
+        petLibrary,
+        petBalancingLibrary,
+    );
+
+    assert.equal(stats.hp, 1100);
+});
+
+test('applies cooldown reduction to both players with the regular battle floor', () => {
+    const engine = new PvpBattleEngine(playerStats(0.25), playerStats(0.95));
+    const snapshot = engine.getSnapshot();
+
+    assert.equal(snapshot.player1Skills[0].cooldown, 7.5);
+    assert.equal(snapshot.player2Skills[0].cooldown, 1);
+});
+
+test('weights already-scaled health buckets without reapplying ascension', () => {
+    const stats = {
+        basePlayerHealth: 100,
+        itemHealth: 100,
+        petHealth: 10,
+        skillPassiveHealth: 20,
+        mountHealth: 30,
+        healthMultiplier: 2,
+        equipHealthMultiplier: 3,
+        skinHealthMulti: 0.25,
+        setHealthMulti: 0.25,
+        totalHealth: 1080,
+        totalDamage: 10,
+    } as AggregatedStats;
+
+    const result = aggregatedStatsToPvpStats(stats, [], {}, undefined, undefined, pvpConfig);
+
+    assert.equal(result.hp, 1110);
+});
+
+test('subtracts common-scaled system health when deriving enemy equipment health', () => {
+    const config = {
+        ...enemyConfig(1600, [{ rarity: 'Rare', id: 7, level: 1, evolution: 0, hp: 100 }]),
+        skillPassiveHp: 100,
+        mount: {
+            rarity: 'Rare',
+            id: 1,
+            level: 1,
+            evolution: 0,
+            skills: [],
+            hp: 100,
+        },
+        passiveStats: {
+            HealthMulti: { enabled: true, value: 100 },
+        },
+    };
+
+    const result = enemyConfigToPvpStats(
+        config,
+        undefined,
+        { ...pvpConfig, PvpHpPetMultiplier: 0.5, PvpHpSkillMultiplier: 0.5, PvpHpMountMultiplier: 0.5 },
+    );
+
+    assert.equal(result.hp, 1300);
+});
+
+test('preserves imported pet, skill, and mount health modifiers', () => {
+    const profile: UserProfile = structuredClone(INITIAL_PROFILE);
+    profile.pets.active = [{ rarity: 'Rare', id: 7, level: 1, evolution: 0 }];
+    profile.mount.active = {
+        rarity: 'Rare',
+        id: 1,
+        level: 1,
+        evolution: 0,
+        skills: [],
+    };
+    profile.misc.petAscensionLevel = 1;
+
+    const stats = {
+        totalDamage: 10,
+        totalHealth: 11100,
+        skillPassiveHealth: 500,
+        mountHealth: 600,
+        healthMultiplier: 2,
+        skillDamageMultiplier: 1,
+        damageMultiplier: 1,
+    };
+    const libs = {
+        petUpgradeLibrary: {
+            Rare: {
+                LevelInfo: [{
+                    Level: 0,
+                    PetStats: {
+                        Stats: [{
+                            Value: 100,
+                            StatNode: { UniqueStat: { StatType: 'Health' } },
+                        }],
+                    },
+                }],
+            },
+        },
+        petLibrary: {
+            "{'Rarity': 'Rare', 'Id': 7}": { Type: 'Tank' },
+        },
+        petBalancingLibrary: {
+            Tank: { DamageMultiplier: 1, HealthMultiplier: 2 },
+        },
+        ascensionConfigsLibrary: {
+            Pets: {
+                AscensionConfigPerLevel: [{
+                    StatContributions: [{
+                        Value: 49,
+                        StatNode: { UniqueStat: { StatType: 'Health' } },
+                    }],
+                }],
+            },
+        },
+    };
+
+    const config = profileToEnemyConfig(profile, libs, stats);
+
+    assert.equal(config.pets[0]?.hp, 10000);
+    assert.equal(config.skillPassiveHp, 500);
+    assert.equal(config.mount?.hp, 600);
+    assert.deepEqual(config.passiveStats.HealthMulti, { enabled: true, value: 100 });
+});

--- a/src/utils/PvpBattleEngine.ts
+++ b/src/utils/PvpBattleEngine.ts
@@ -7,33 +7,49 @@
 
 import type { WeaponInfo } from './BattleHelper';
 import { SKILL_MECHANICS } from './constants';
-import { StatEngine } from './statEngine';
+import { StatEngine, type AggregatedStats } from './statEngine';
 import { PetSlot, MountSlot, UserProfile } from '../types/Profile';
 
 // --- Shared Helpers ---
 
-const getAscMulti = (category: string, level: number, target: string = 'Damage', ascensionConfigsLibrary: any = null) => {
-    let multi = 0;
-    if (level > 0 && ascensionConfigsLibrary?.[category]?.AscensionConfigPerLevel) {
-        const configs = ascensionConfigsLibrary[category].AscensionConfigPerLevel;
-        for (let i = 0; i < level && i < configs.length; i++) {
-            const contributions = configs[i].StatContributions || [];
-            for (const s of contributions) {
-                const sType = s.StatNode?.UniqueStat?.StatType;
-                const sTarget = s.StatNode?.StatTarget?.$type;
-                if (sType === target) {
-                    if (category === 'Skills') {
-                        const isActive = sTarget === 'ActiveSkillStatTarget';
-                        if (target === 'Damage' && isActive) multi += s.Value;
-                        if (target === 'Health' && isActive) multi += s.Value;
-                    } else {
-                        multi += s.Value;
-                    }
-                }
-            }
-        }
-    }
-    return multi;
+const getPetAscensionHealthMultiplier = (level: number, ascensionConfigsLibrary: any): number => {
+    const configs = ascensionConfigsLibrary?.Pets?.AscensionConfigPerLevel;
+    if (level <= 0 || !configs?.length) return 1;
+
+    const config = configs[Math.min(level - 1, configs.length - 1)];
+    const healthStat = config?.StatContributions?.find((stat: any) => {
+        const type = stat.StatNode?.UniqueStat?.StatType;
+        return type === 'Health' || type === 'AscensionHealth';
+    });
+    return healthStat ? healthStat.Value + 1 : 1;
+};
+
+const calculatePetHealth = (
+    pet: PetSlot,
+    petUpgradeLibrary: any,
+    petLibrary: any,
+    petBalancingLibrary: any,
+    ascensionConfigsLibrary?: any,
+    healthBonus: number = 0,
+    ascensionLevel: number = 0
+): number => {
+    const upgradeData = petUpgradeLibrary?.[pet.rarity];
+    if (!upgradeData?.LevelInfo) return 0;
+
+    const levelIndex = Math.max(0, pet.level - 1);
+    const levelInfo = upgradeData.LevelInfo.find((entry: any) => entry.Level === levelIndex)
+        || upgradeData.LevelInfo[0];
+    const healthStat = levelInfo?.PetStats?.Stats?.find(
+        (stat: any) => stat.StatNode?.UniqueStat?.StatType === 'Health'
+    );
+    if (!healthStat) return 0;
+
+    const key = `{'Rarity': '${pet.rarity}', 'Id': ${pet.id}}`;
+    const petType = petLibrary?.[key]?.Type || 'Balanced';
+    const typeMultiplier = petBalancingLibrary?.[petType]?.HealthMultiplier ?? 1;
+    const ascensionMultiplier = getPetAscensionHealthMultiplier(ascensionLevel, ascensionConfigsLibrary);
+
+    return (healthStat.Value || 0) * typeMultiplier * (1 + healthBonus) * ascensionMultiplier;
 };
 
 // --- Types ---
@@ -259,8 +275,8 @@ export class PvpBattleEngine {
     constructor(player1Stats: PvpPlayerStats, player2Stats: PvpPlayerStats) {
         this.player1 = this.createEntity(1, true, player1Stats, 2);
         this.player2 = this.createEntity(2, false, player2Stats, 23);
-        this.player1Skills = this.createSkillStates(player1Stats.skills, true);
-        this.player2Skills = this.createSkillStates(player2Stats.skills, false);
+        this.player1Skills = this.createSkillStates(player1Stats.skills, player1Stats.skillCooldownMulti);
+        this.player2Skills = this.createSkillStates(player2Stats.skills, player2Stats.skillCooldownMulti);
         this.initializeRegen(this.player1, player1Stats);
         this.initializeRegen(this.player2, player2Stats);
         this.addLog('BATTLE_START', `Battle started between ${player1Stats.skills.length} skills and ${player2Stats.skills.length} skills`);
@@ -298,7 +314,8 @@ export class PvpBattleEngine {
         entity.regenSnapshotTimer = 0;
     }
 
-    private createSkillStates(skills: PvpSkillConfig[], _isPlayer1: boolean): SkillState[] {
+    private createSkillStates(skills: PvpSkillConfig[], cooldownReduction: number): SkillState[] {
+        const cooldownMultiplier = Math.max(0.1, 1 - cooldownReduction);
         return skills.map(skill => {
             const mechanics = SKILL_MECHANICS[skill.id] || { count: 1 };
             const count = Math.max(1, skill.count || mechanics.count || 1);
@@ -329,7 +346,8 @@ export class PvpBattleEngine {
                 activeHeal = healthPerHit;
             }
             return {
-                id: skill.id, activeDuration: skill.duration, cooldown: skill.cooldown,
+                id: skill.id, activeDuration: skill.duration,
+                cooldown: Math.max(0.1, skill.cooldown * cooldownMultiplier),
                 state: 'Startup', timer: SKILL_STARTUP_TIME, damage: activeDamage, healAmount: activeHeal,
                 isBuff: isBuffSkill, bonusDamage: bonusDamage, bonusMaxHealth: bonusMaxHealth,
                 count: count, interval: mechanics.interval || 0.1, delay: mechanics.delay || 0,
@@ -657,8 +675,8 @@ export function simulatePvpBattleMulti(player1Stats: PvpPlayerStats, player2Stat
 
 export function enemyConfigToPvpStats(
     enemyConfig: any, weaponLibrary?: any, pvpBaseConfig?: any,
-    _mountUpgradeLibrary?: any, petLibrary?: any, petBalancingLibrary?: any,
-    _ascensionConfigsLibrary?: any
+    _mountUpgradeLibrary?: any, petUpgradeLibrary?: any, petLibrary?: any,
+    petBalancingLibrary?: any, ascensionConfigsLibrary?: any
 ): PvpPlayerStats {
     let weaponInfo: WeaponInfo | undefined;
     if (enemyConfig.weaponId && weaponLibrary) {
@@ -723,17 +741,15 @@ export function enemyConfigToPvpStats(
         enemyConfig.pets.forEach((pet: any) => {
             if (pet) {
                 if (pet.hp && pet.hp > 0) calculatedPetHp += pet.hp;
-                else if (pet.id !== undefined && petLibrary && petBalancingLibrary) {
-                    const key = `{'Rarity': '${pet.rarity}', 'Id': ${pet.id}}`;
-                    const petData = petLibrary[key];
-                    if (petData) {
-                        const bal = petBalancingLibrary[petData.Type];
-                        if (bal) {
-                            const levelIdx = Math.max(0, pet.level - 1);
-                            calculatedPetHp += (bal.BaseHealthPerLevel?.[levelIdx] || 0) + (bal.HealthPerRarity?.[petData.Rarity] || 0);
-                        }
-                    }
-                }
+                else calculatedPetHp += calculatePetHealth(
+                    pet,
+                    petUpgradeLibrary,
+                    petLibrary,
+                    petBalancingLibrary,
+                    ascensionConfigsLibrary,
+                    0,
+                    enemyConfig.petAscensionLevel || 0
+                );
             }
         });
     }
@@ -742,14 +758,14 @@ export function enemyConfigToPvpStats(
     const setHpFactor = enemyConfig.hasCompleteSet ? 0.10 : (enemyConfig.stats.setHpMulti || 0);
     const globalSkinSetFactor = skinHpFactor + setHpFactor;
 
-    // Perfect Reverse: Values provided by user (Total HP, Pet HP, etc.) are already scaled by ASC/Tech in-game.
-    const petHpInGame = calculatedPetHp;
-    const skillPassiveHpInGame = enemyConfig.skillPassiveHp || 0;
-    const mountHpInGame = enemyConfig.mount?.hp || 0;
-    const totalSystemHpInGame = petHpInGame + skillPassiveHpInGame + mountHpInGame;
+    const commonHealthMultiplier = 1 + healthMulti;
+    const petHp = calculatedPetHp;
+    const skillPassiveHp = enemyConfig.skillPassiveHp || 0;
+    const mountHp = enemyConfig.mount?.hp || 0;
+    const totalSystemHp = (petHp + skillPassiveHp + mountHp) * commonHealthMultiplier;
 
     const totalHpBeforeGlobal = (enemyConfig.stats.hp || 10000) / Math.max(0.01, globalSkinSetFactor);
-    let derivedEquipHpWithMulti = totalHpBeforeGlobal - totalSystemHpInGame;
+    let derivedEquipHpWithMulti = totalHpBeforeGlobal - totalSystemHp;
     derivedEquipHpWithMulti = Math.max(0, derivedEquipHpWithMulti);
 
     const pvpHpBaseMulti = pvpBaseConfig?.PvpHpBaseMultiplier ?? 1.0;
@@ -758,9 +774,9 @@ export function enemyConfigToPvpStats(
     const pvpHpMountMulti = pvpBaseConfig?.PvpHpMountMultiplier ?? 2.0;
 
     const pvpEquipHp = derivedEquipHpWithMulti * pvpHpBaseMulti;
-    const pvpPetHp = petHpInGame * pvpHpPetMulti;
-    const pvpSkillHp = skillPassiveHpInGame * pvpHpSkillMulti;
-    const pvpMountHp = mountHpInGame * pvpHpMountMulti;
+    const pvpPetHp = petHp * commonHealthMultiplier * pvpHpPetMulti;
+    const pvpSkillHp = skillPassiveHp * commonHealthMultiplier * pvpHpSkillMulti;
+    const pvpMountHp = mountHp * commonHealthMultiplier * pvpHpMountMulti;
 
     const pvpTotalHp = (pvpEquipHp + pvpPetHp + pvpSkillHp + pvpMountHp) * globalSkinSetFactor;
 
@@ -781,9 +797,8 @@ export function enemyConfigToPvpStats(
 }
 
 export function aggregatedStatsToPvpStats(
-    stats: any, equippedSkills: any[], skillLibrary: any,
-    weaponLibrary?: any, weaponSlot?: any, pvpBaseConfig?: any,
-    ascensionLevels: Record<string, number> = {}, ascensionConfigsLibrary: any = null
+    stats: AggregatedStats, equippedSkills: any[], skillLibrary: any,
+    weaponLibrary?: any, weaponSlot?: any, pvpBaseConfig?: any
 ): PvpPlayerStats {
     const skills: PvpSkillConfig[] = equippedSkills.map(skill => {
         const skillData = skillLibrary?.[skill.id];
@@ -802,29 +817,19 @@ export function aggregatedStatsToPvpStats(
         };
     });
 
-    const commonHealthMulti = 1 + (stats.secondaryHealthMulti || 0);
-    const equipHealthMulti = stats.healthMultiplier || commonHealthMulti;
-    const forgeAscHpBonus = Math.max(0, equipHealthMulti - commonHealthMulti);
+    const commonHealthMulti = stats.healthMultiplier || 1;
+    const equipHealthMulti = stats.equipHealthMultiplier || commonHealthMulti;
     const globalSkinSetFactor = (1 + (stats.skinHealthMulti || 0)) + (stats.setHealthMulti || 0);
-    const totalSystemHp = (stats.petHealth || 0) + (stats.skillPassiveHealth || 0) + (stats.mountHealth || 0);
-
-    const totalHpBeforeGlobal = (stats.totalHealth || 10000) / Math.max(0.01, globalSkinSetFactor);
-    let derivedEquipHp = (totalHpBeforeGlobal - totalSystemHp) / Math.max(0.01, equipHealthMulti);
-    derivedEquipHp = Math.max(0, derivedEquipHp);
 
     const pvpHpBaseMulti = pvpBaseConfig?.PvpHpBaseMultiplier ?? 1.0;
     const pvpHpPetMulti = pvpBaseConfig?.PvpHpPetMultiplier ?? 0.5;
     const pvpHpSkillMulti = pvpBaseConfig?.PvpHpSkillMultiplier ?? 0.5;
     const pvpHpMountMulti = pvpBaseConfig?.PvpHpMountMultiplier ?? 2.0;
 
-    const petAscMultiHp = getAscMulti('Pets', ascensionLevels.pets || 0, 'Health', ascensionConfigsLibrary);
-    const skillAscMultiHp = getAscMulti('Skills', ascensionLevels.skills || 0, 'Health', ascensionConfigsLibrary);
-    const mountAscMultiHp = getAscMulti('Mounts', ascensionLevels.mounts || 0, 'Health', ascensionConfigsLibrary);
-
-    const pvpEquipHp = derivedEquipHp * (commonHealthMulti + (forgeAscHpBonus * pvpHpBaseMulti));
-    const pvpPetHp = (stats.petHealth || 0) * (1 + petAscMultiHp) * pvpHpPetMulti;
-    const pvpSkillHp = (stats.skillPassiveHealth || 0) * (1 + skillAscMultiHp) * pvpHpSkillMulti;
-    const pvpMountHp = (stats.mountHealth || 0) * (1 + mountAscMultiHp) * pvpHpMountMulti;
+    const pvpEquipHp = (stats.basePlayerHealth + stats.itemHealth) * equipHealthMulti * pvpHpBaseMulti;
+    const pvpPetHp = stats.petHealth * commonHealthMulti * pvpHpPetMulti;
+    const pvpSkillHp = stats.skillPassiveHealth * commonHealthMulti * pvpHpSkillMulti;
+    const pvpMountHp = stats.mountHealth * commonHealthMulti * pvpHpMountMulti;
 
     const pvpTotalHp = (pvpEquipHp + pvpPetHp + pvpSkillHp + pvpMountHp) * globalSkinSetFactor;
 
@@ -868,20 +873,13 @@ export function profileToEnemyConfig(profile: UserProfile, libs: any, existingSt
     const techModifiers = engine.getTechModifiers();
     const petBonusHp = techModifiers['PetBonusHealth'] || 0;
     const petAscLevel = profile.misc?.petAscensionLevel || 0;
-    const petAscMulti = getAscMulti('Pets', petAscLevel, 'Health', libs.ascensionConfigsLibrary);
-    const petDeScale = 1 + petBonusHp + petAscMulti;
-
-    const skillBonusHp = techModifiers['SkillPassiveHealth'] || 0;
-    const skillAscLevel = profile.misc?.skillAscensionLevel || 0;
-    const skillAscMulti = getAscMulti('Skills', skillAscLevel, 'Health', libs.ascensionConfigsLibrary);
-    const skillDeScale = 1 + skillBonusHp + skillAscMulti;
 
     const config: EnemyConfig = {
         name: profile.name || 'Imported Profile',
         level: profile.misc?.forgeLevel || 1,
         weaponId: profile.items.Weapon?.idx || 0,
         weapon: profile.items.Weapon || null,
-        skillPassiveHp: Math.round((stats.skillPassiveHealth / Math.max(0.01, stats.healthMultiplier || 1)) / Math.max(0.01, skillDeScale)),
+        skillPassiveHp: stats.skillPassiveHealth,
         stats: {
             damage: stats.totalDamage,
             hp: stats.totalHealth,
@@ -943,20 +941,22 @@ export function profileToEnemyConfig(profile: UserProfile, libs: any, existingSt
             return false;
         })(),
         passiveStats: {},
-        pets: profile.pets?.active.map((p: any) => ({ ...p, hp: p.hp ? Math.round(p.hp / Math.max(0.01, petDeScale)) : 0 })) || [],
+        pets: profile.pets?.active.map((pet: PetSlot) => ({
+            ...pet,
+            hp: calculatePetHealth(
+                pet,
+                libs.petUpgradeLibrary,
+                libs.petLibrary,
+                libs.petBalancingLibrary,
+                libs.ascensionConfigsLibrary,
+                petBonusHp,
+                petAscLevel
+            )
+        })) || [],
         mount: (() => {
             const m = profile.mount?.active;
             if (!m) return null;
-            const mountAscLevel = profile.misc?.mountAscensionLevel || 0;
-            let mountAscMulti = 0;
-            if (mountAscLevel > 0 && libs.ascensionConfigsLibrary?.Mounts?.AscensionConfigPerLevel) {
-                const configs = libs.ascensionConfigsLibrary.Mounts.AscensionConfigPerLevel;
-                for (let i = 0; i < mountAscLevel && i < configs.length; i++) {
-                    configs[i].StatContributions?.forEach((s: any) => { if (s.StatNode?.UniqueStat?.StatType === 'Health') mountAscMulti += s.Value; });
-                }
-            }
-            const deScale = (1 + (techModifiers['MountHealth'] || 0) + mountAscMulti);
-            return { ...m, hp: Math.round((stats.mountHealth || 0) / Math.max(0.01, deScale)) };
+            return { ...m, hp: stats.mountHealth || 0 };
         })()
     };
     const ps = ['DamageMulti', 'HealthMulti', 'CriticalChance', 'CriticalMulti', 'BlockChance', 'LifeSteal', 'DoubleDamageChance', 'HealthRegen', 'SkillDamageMulti', 'SkillCooldownMulti', 'AttackSpeed'];
@@ -977,6 +977,6 @@ export function profileToEnemyConfig(profile: UserProfile, libs: any, existingSt
     setP('SkillCooldownMulti', getNet('SkillCooldownMulti', stats.skillCooldownReduction));
     setP('AttackSpeed', getNet('AttackSpeed', stats.attackSpeedMultiplier, true));
     setP('DamageMulti', getNet('DamageMulti', stats.secondaryDamageMulti || 0));
-    setP('HealthMulti', getNet('HealthMulti', stats.secondaryHealthMulti || 0));
+    setP('HealthMulti', getNet('HealthMulti', stats.healthMultiplier || 1, true));
     return config;
 }


### PR DESCRIPTION
## Summary

- calculate missing pet health from `PetUpgradeLibrary`
- preserve the health multiplier layers produced by `StatEngine`
- avoid applying pet and mount ascension twice
- preserve imported pet, skill-passive, and mount health
- apply skill cooldown reduction to both PvP players

## Tests

- `npm run test:pvp`
- `npx tsc --noEmit --pretty false`
- `npx vite build`

Closes #14
Closes #15
Closes #16
Closes #17
Closes #18

#10 and #11 are intentionally excluded because they are handled by #12 and #13.
